### PR TITLE
Fix Illuria scene marker targets

### DIFF
--- a/WismUnity/Assets/Scenes/Illuria.unity
+++ b/WismUnity/Assets/Scenes/Illuria.unity
@@ -144,231 +144,322 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7088d912908f9284a83960d7ba0e2b8f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &11935018
-GameObject:
+--- !u!1001 &17868655
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 11935019}
-  - component: {fileID: 11935020}
-  m_Layer: 0
-  m_Name: SeeroftheRiver
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &11935019
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 11935018}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 98, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &11935020
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 11935018}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: SeeroftheRiver
---- !u!1 &14100626
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 14100627}
-  - component: {fileID: 14100628}
-  m_Layer: 0
-  m_Name: TempleofLurinth
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &14100627
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Ohmsmouth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Ohmsmouth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &17868656 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 17868655}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 14100626}
+--- !u!1001 &25881320
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 105, y: 22, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &14100628
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 14100626}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TempleofLurinth
---- !u!1 &35647828
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 35647829}
-  - component: {fileID: 35647830}
-  m_Layer: 0
-  m_Name: Needleton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &35647829
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Beleri
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Beleri
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &25881321 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 25881320}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 35647828}
+--- !u!1001 &29706986
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 56, y: 127, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &35647830
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 35647828}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Needleton
---- !u!1 &38491914
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 38491915}
-  - component: {fileID: 38491916}
-  m_Layer: 0
-  m_Name: Deephallow
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &38491915
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 74.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: TempleofMiridine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: TempleofMiridine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &29706987 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 29706986}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 38491914}
+--- !u!1001 &50456781
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 60, y: 124, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &38491916
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 38491914}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Deephallow
---- !u!1 &41186226
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 41186227}
-  - component: {fileID: 41186228}
-  m_Layer: 0
-  m_Name: GreatLibrary
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &41186227
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Ungor
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 136
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Ungor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &50456782 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 50456781}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 41186226}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 38, y: 62, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &41186228
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 41186226}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: GreatLibrary
 --- !u!224 &55671594 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 1337930119180113733, guid: 178c2d9816bbf41469f77816e2281a02,
@@ -458,7 +549,165 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &63543185
+--- !u!1001 &70628846
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Waybourne
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 103
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Waybourne
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &70628847 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 70628846}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &77911053
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 42.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 37.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: TowerofDeath
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: TowerofDeath
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &77911054 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 77911053}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &81254369
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -466,142 +715,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 63543186}
-  - component: {fileID: 63543187}
+  - component: {fileID: 81254370}
+  - component: {fileID: 81254371}
   m_Layer: 0
-  m_Name: Argenthorn
+  m_Name: S17W-42
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &63543186
+--- !u!4 &81254370
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 63543185}
+  m_GameObject: {fileID: 81254369}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 42, y: 41, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &63543187
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 63543185}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Argenthorn
---- !u!1 &65750852
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 65750853}
-  - component: {fileID: 65750854}
-  m_Layer: 0
-  m_Name: S17W-06
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &65750853
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 65750852}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 15, y: 72, z: 0}
+  m_LocalPosition: {x: 72, y: 37, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &65750854
+--- !u!114 &81254371
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 65750852}
+  m_GameObject: {fileID: 81254369}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-06
-  mapByteOffset: 18124
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &74526220
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 74526221}
-  - component: {fileID: 74526222}
-  m_Layer: 0
-  m_Name: S17W-54
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &74526221
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 74526220}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 89, y: 77, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &74526222
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 74526220}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-54
-  mapByteOffset: 17182
+  siteAnchorId: S17W-42
+  mapByteOffset: 25868
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -737,7 +888,171 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!1 &98160894
+--- !u!1001 &108376950
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: ArArak
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 95
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: ArArak
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &108376951 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 108376950}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &122297116 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4866160464913853227, guid: b94260a4073957b4e8e6e2897bf96468,
+    type: 3}
+  m_PrefabInstance: {fileID: 4866160464934432823}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &126705776
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: BaladNaran
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 51
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: BaladNaran
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &126705777 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 126705776}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &128346274
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -745,134 +1060,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 98160895}
-  - component: {fileID: 98160896}
+  - component: {fileID: 128346275}
+  - component: {fileID: 128346276}
   m_Layer: 0
-  m_Name: Greenweigh
+  m_Name: S17W-14
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &98160895
+--- !u!4 &128346275
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 98160894}
+  m_GameObject: {fileID: 128346274}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 29, y: 102, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &98160896
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 98160894}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Greenweigh
---- !u!1 &104509487
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 104509488}
-  - component: {fileID: 104509489}
-  m_Layer: 0
-  m_Name: GreyportRuins
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &104509488
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 104509487}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7, y: 121, z: 0}
+  m_LocalPosition: {x: 23, y: 128, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &104509489
+--- !u!114 &128346276
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 104509487}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: GreyportRuins
---- !u!1 &108245968
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 108245969}
-  - component: {fileID: 108245970}
-  m_Layer: 0
-  m_Name: S17W-11
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &108245969
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 108245968}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 20, y: 17, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &108245970
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 108245968}
+  m_GameObject: {fileID: 128346274}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-11
-  mapByteOffset: 30124
+  siteAnchorId: S17W-14
+  mapByteOffset: 5932
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -880,102 +1105,6 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!224 &122297116 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4866160464913853227, guid: b94260a4073957b4e8e6e2897bf96468,
-    type: 3}
-  m_PrefabInstance: {fileID: 4866160464934432823}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &127820316
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 127820317}
-  - component: {fileID: 127820318}
-  m_Layer: 0
-  m_Name: PaKur
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &127820317
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 127820316}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 86, y: 75, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &127820318
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 127820316}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: PaKur
---- !u!1 &140661881
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 140661882}
-  - component: {fileID: 140661883}
-  m_Layer: 0
-  m_Name: GoldenLibrary
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &140661882
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 140661881}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 11, y: 38, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &140661883
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 140661881}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: GoldenLibrary
 --- !u!1 &149804620
 GameObject:
   m_ObjectHideFlags: 0
@@ -1100,51 +1229,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 5550251712330856359}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &156299710
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 156299711}
-  - component: {fileID: 156299712}
-  m_Layer: 0
-  m_Name: Ssuri
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &156299711
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 156299710}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 59, y: 43, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &156299712
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 156299710}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Ssuri
 --- !u!1 &156407253 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6261160846156219877, guid: 70acb6acfe7e1f4448343a7120ac4ceb,
@@ -1157,59 +1241,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 6261160846310461488}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &170837494
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 170837495}
-  - component: {fileID: 170837496}
-  m_Layer: 0
-  m_Name: S17W-35
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &170837495
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170837494}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 67, y: 14, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &170837496
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 170837494}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-35
-  mapByteOffset: 30872
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
 --- !u!1 &186682938
 GameObject:
   m_ObjectHideFlags: 0
@@ -1302,7 +1333,86 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 100, y: 100}
   m_EdgeRadius: 0
---- !u!1 &191204431
+--- !u!1001 &199481285
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: TheOldInn
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: TheOldInn
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &199481286 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 199481285}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &204114861
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1310,44 +1420,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 191204432}
-  - component: {fileID: 191204433}
+  - component: {fileID: 204114862}
+  - component: {fileID: 204114863}
   m_Layer: 0
-  m_Name: S17W-57
+  m_Name: S17W-54
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &191204432
+--- !u!4 &204114862
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 191204431}
+  m_GameObject: {fileID: 204114861}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91, y: 56, z: 0}
+  m_LocalPosition: {x: 89, y: 77, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &191204433
+--- !u!114 &204114863
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 191204431}
+  m_GameObject: {fileID: 204114861}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-57
-  mapByteOffset: 21764
+  siteAnchorId: S17W-54
+  mapByteOffset: 17182
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -1355,7 +1465,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &213843996
+--- !u!1 &205536470
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1363,43 +1473,183 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 213843997}
-  - component: {fileID: 213843998}
+  - component: {fileID: 205536471}
+  - component: {fileID: 205536472}
   m_Layer: 0
-  m_Name: Ilnyr
+  m_Name: S17W-26
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &213843997
+--- !u!4 &205536471
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 213843996}
+  m_GameObject: {fileID: 205536470}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 71, y: 61, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_LocalPosition: {x: 52, y: 54, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1000689320}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &213843998
+--- !u!114 &205536472
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 213843996}
+  m_GameObject: {fileID: 205536470}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Ilnyr
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-26
+  mapByteOffset: 22122
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &209138479
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 209138480}
+  - component: {fileID: 209138481}
+  m_Layer: 0
+  m_Name: S17W-31
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &209138480
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 209138479}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 57, y: 22, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &209138481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 209138479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-31
+  mapByteOffset: 29108
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &220138561
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Deserton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 93
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 153
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Deserton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &220138562 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 220138561}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &222812354
 GameObject:
   m_ObjectHideFlags: 0
@@ -1468,7 +1718,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &232725003
+--- !u!1 &242299944
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1476,44 +1726,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 232725004}
-  - component: {fileID: 232725005}
+  - component: {fileID: 242299945}
+  - component: {fileID: 242299946}
   m_Layer: 0
-  m_Name: S17W-49
+  m_Name: S17W-28
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &232725004
+--- !u!4 &242299945
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 232725003}
+  m_GameObject: {fileID: 242299944}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 114, z: 0}
+  m_LocalPosition: {x: 55, y: 33, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &232725005
+--- !u!114 &242299946
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 232725003}
+  m_GameObject: {fileID: 242299944}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-49
-  mapByteOffset: 9092
+  siteAnchorId: S17W-28
+  mapByteOffset: 26706
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -1521,7 +1771,165 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &249791407
+--- !u!1001 &261949983
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Marton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 109
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Marton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &261949984 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 261949983}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &273032722
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Quiesce
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Quiesce
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &273032723 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 273032722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &274702070
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1529,89 +1937,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 249791408}
-  - component: {fileID: 249791409}
+  - component: {fileID: 274702071}
+  - component: {fileID: 274702072}
   m_Layer: 0
-  m_Name: Malikor
+  m_Name: S17W-24
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &249791408
+--- !u!4 &274702071
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 249791407}
+  m_GameObject: {fileID: 274702070}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 98, y: 117, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &249791409
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 249791407}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Malikor
---- !u!1 &273204885
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 273204886}
-  - component: {fileID: 273204887}
-  m_Layer: 0
-  m_Name: S17W-15
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &273204886
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 273204885}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 23, y: 116, z: 0}
+  m_LocalPosition: {x: 50, y: 17, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &273204887
+--- !u!114 &274702072
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 273204885}
+  m_GameObject: {fileID: 274702070}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-15
-  mapByteOffset: 8548
+  siteAnchorId: S17W-24
+  mapByteOffset: 30184
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -1619,7 +1982,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &281114111
+--- !u!1001 &286589482
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Greenweigh
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Greenweigh
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &286589483 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 286589482}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &287395395
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1627,89 +2069,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 281114112}
-  - component: {fileID: 281114113}
+  - component: {fileID: 287395396}
+  - component: {fileID: 287395397}
   m_Layer: 0
-  m_Name: Garom
+  m_Name: S17W-29
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &281114112
+--- !u!4 &287395396
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 281114111}
+  m_GameObject: {fileID: 287395395}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 87, y: 40, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &281114113
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 281114111}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Garom
---- !u!1 &281377095
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 281377096}
-  - component: {fileID: 281377097}
-  m_Layer: 0
-  m_Name: S17W-02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &281377096
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 281377095}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5, y: 132, z: 0}
+  m_LocalPosition: {x: 56, y: 17, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &281377097
+--- !u!114 &287395397
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 281377095}
+  m_GameObject: {fileID: 287395395}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-02
-  mapByteOffset: 5024
+  siteAnchorId: S17W-29
+  mapByteOffset: 30196
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -1717,56 +2114,90 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &285019229
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 285019230}
-  - component: {fileID: 285019231}
-  m_Layer: 0
-  m_Name: HallsofChaos
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &285019230
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 285019229}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 86, y: 105, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &285019231
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 285019229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: HallsofChaos
 --- !u!224 &315151239 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2107104533398651432, guid: 383aa00ac70095c479df23749f4cd40b,
     type: 3}
   m_PrefabInstance: {fileID: 2107104533688570287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &333493213
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 102.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 154.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: TempleofEmrik
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: TempleofEmrik
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &333493214 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 333493213}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &336097773 stripped
 MonoBehaviour:
@@ -1910,7 +2341,86 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 5039577764986272526}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &356132681
+--- !u!1001 &371174453
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: EmperorsCrypt
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: EmperorsCrypt
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &371174454 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 371174453}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &386410571
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1918,140 +2428,295 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 356132682}
-  - component: {fileID: 356132683}
+  - component: {fileID: 386410572}
+  - component: {fileID: 386410573}
   m_Layer: 0
-  m_Name: BaladNaran
+  m_Name: S17W-25
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &356132682
+--- !u!4 &386410572
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 356132681}
+  m_GameObject: {fileID: 386410571}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 90, y: 51, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &356132683
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 356132681}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: BaladNaran
---- !u!1 &379460440
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 379460441}
-  - component: {fileID: 379460442}
-  m_Layer: 0
-  m_Name: Deserton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &379460441
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 379460440}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 93, y: 153, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &379460442
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 379460440}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Deserton
---- !u!1 &393786953
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 393786954}
-  - component: {fileID: 393786955}
-  m_Layer: 0
-  m_Name: Monolyth
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &393786954
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393786953}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 9, y: 155, z: 0}
+  m_LocalPosition: {x: 52, y: 112, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &393786955
+--- !u!114 &386410573
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 393786953}
+  m_GameObject: {fileID: 386410571}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: Monolyth
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-25
+  mapByteOffset: 9478
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &417777433
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Elvallie
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Elvallie
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &417777434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 417777433}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &418848444 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6703045709133836704, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
     type: 3}
   m_PrefabInstance: {fileID: 3274794878370800250}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &427689073
+--- !u!1001 &425138699
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 125.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: TempleofIris
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: TempleofIris
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &425138700 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 425138699}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &438705025
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Tirfing
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 143
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Tirfing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &438705026 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 438705025}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &458103044
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2059,134 +2724,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 427689074}
-  - component: {fileID: 427689075}
+  - component: {fileID: 458103045}
+  - component: {fileID: 458103046}
   m_Layer: 0
-  m_Name: Meneloth
+  m_Name: S17W-45
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &427689074
+--- !u!4 &458103045
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 427689073}
+  m_GameObject: {fileID: 458103044}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 67, y: 117, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &427689075
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 427689073}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Meneloth
---- !u!1 &431364161
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 431364162}
-  - component: {fileID: 431364163}
-  m_Layer: 0
-  m_Name: Stormheim
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &431364162
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 431364161}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 19, y: 47, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &431364163
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 431364161}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Stormheim
---- !u!1 &455852677
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 455852678}
-  - component: {fileID: 455852679}
-  m_Layer: 0
-  m_Name: S17W-38
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &455852678
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 455852677}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 70, y: 18, z: 0}
+  m_LocalPosition: {x: 73, y: 32, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &455852679
+--- !u!114 &458103046
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 455852677}
+  m_GameObject: {fileID: 458103044}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-38
-  mapByteOffset: 30006
+  siteAnchorId: S17W-45
+  mapByteOffset: 26960
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -2194,7 +2769,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &476688041
+--- !u!1001 &463877895
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 121.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: GreyportRuins
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: GreyportRuins
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &463877896 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 463877895}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &466131450
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2202,44 +2856,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 476688042}
-  - component: {fileID: 476688043}
+  - component: {fileID: 466131451}
+  - component: {fileID: 466131452}
   m_Layer: 0
-  m_Name: S17W-41
+  m_Name: S17W-37
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &476688042
+--- !u!4 &466131451
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476688041}
+  m_GameObject: {fileID: 466131450}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 56, z: 0}
+  m_LocalPosition: {x: 70, y: 97, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &476688043
+--- !u!114 &466131452
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476688041}
+  m_GameObject: {fileID: 466131450}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-41
-  mapByteOffset: 21726
+  siteAnchorId: S17W-37
+  mapByteOffset: 12784
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -2247,7 +2901,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &480800640
+--- !u!1001 &466475493
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Khamar
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 39
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 92
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Khamar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &466475494 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 466475493}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &482302818
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2255,134 +2988,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 480800641}
-  - component: {fileID: 480800642}
+  - component: {fileID: 482302819}
+  - component: {fileID: 482302820}
   m_Layer: 0
-  m_Name: Cragmorton
+  m_Name: S17W-18
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &480800641
+--- !u!4 &482302819
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 480800640}
+  m_GameObject: {fileID: 482302818}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 34, y: 89, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &480800642
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 480800640}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Cragmorton
---- !u!1 &488372531
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 488372532}
-  - component: {fileID: 488372533}
-  m_Layer: 0
-  m_Name: AkGiriel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &488372532
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 488372531}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 28, y: 123, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &488372533
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 488372531}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: AkGiriel
---- !u!1 &494074085
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 494074086}
-  - component: {fileID: 494074087}
-  m_Layer: 0
-  m_Name: S17W-24
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &494074086
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 494074085}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 50, y: 17, z: 0}
+  m_LocalPosition: {x: 37, y: 69, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &494074087
+--- !u!114 &482302820
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 494074085}
+  m_GameObject: {fileID: 482302818}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-24
-  mapByteOffset: 30184
+  siteAnchorId: S17W-18
+  mapByteOffset: 18822
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -2390,7 +3033,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &505423196
+--- !u!1 &498158719
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2398,89 +3041,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 505423197}
-  - component: {fileID: 505423198}
+  - component: {fileID: 498158720}
+  - component: {fileID: 498158721}
   m_Layer: 0
-  m_Name: Angbar
+  m_Name: S17W-12
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &505423197
+--- !u!4 &498158720
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 505423196}
+  m_GameObject: {fileID: 498158719}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 54, y: 45, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &505423198
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 505423196}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Angbar
---- !u!1 &507540973
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 507540974}
-  - component: {fileID: 507540975}
-  m_Layer: 0
-  m_Name: S17W-64
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &507540974
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 507540973}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 97, y: 115, z: 0}
+  m_LocalPosition: {x: 22, y: 30, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &507540975
+--- !u!114 &498158721
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 507540973}
+  m_GameObject: {fileID: 498158719}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-64
-  mapByteOffset: 8914
+  siteAnchorId: S17W-12
+  mapByteOffset: 27294
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -2488,7 +3086,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &514582118
+--- !u!1 &501127552
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2496,44 +3094,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 514582119}
-  - component: {fileID: 514582120}
+  - component: {fileID: 501127553}
+  - component: {fileID: 501127554}
   m_Layer: 0
-  m_Name: S17W-28
+  m_Name: S17W-39
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &514582119
+--- !u!4 &501127553
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 514582118}
+  m_GameObject: {fileID: 501127552}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 55, y: 33, z: 0}
+  m_LocalPosition: {x: 72, y: 114, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &514582120
+--- !u!114 &501127554
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 514582118}
+  m_GameObject: {fileID: 501127552}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-28
-  mapByteOffset: 26706
+  siteAnchorId: S17W-39
+  mapByteOffset: 9082
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -2553,7 +3151,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &524239829
+--- !u!1 &522548136
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2561,230 +3159,285 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 524239830}
-  - component: {fileID: 524239831}
+  - component: {fileID: 522548138}
+  - component: {fileID: 522548137}
   m_Layer: 0
-  m_Name: Tasme
+  m_Name: Cities
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &524239830
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 524239829}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8, y: 42, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &524239831
+--- !u!114 &522548137
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 524239829}
+  m_GameObject: {fileID: 522548136}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
+  m_Script: {fileID: 11500000, guid: aa2d8012b36e9824a897a0799127ab63, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Tasme
---- !u!1 &524802056
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 524802057}
-  - component: {fileID: 524802058}
-  m_Layer: 0
-  m_Name: NirnsDeep
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &524802057
+  m_EditorClassIdentifier: UnityGame::CityContainer
+  ImportCitesFromTilemap: 0
+  Reset: 0
+  CityPrefab: {fileID: 0}
+  TotalCities: 0
+--- !u!4 &522548138
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 524802056}
+  m_GameObject: {fileID: 522548136}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 55, y: 119, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Children:
+  - {fileID: 828835894}
+  - {fileID: 814302603}
+  - {fileID: 771466589}
+  - {fileID: 1461372681}
+  - {fileID: 2119169035}
+  - {fileID: 2046591604}
+  - {fileID: 1350915013}
+  - {fileID: 1773672588}
+  - {fileID: 1125684620}
+  - {fileID: 1175321533}
+  - {fileID: 286589483}
+  - {fileID: 628227965}
+  - {fileID: 572843665}
+  - {fileID: 779035665}
+  - {fileID: 1641722178}
+  - {fileID: 1214904168}
+  - {fileID: 50456782}
+  - {fileID: 2124823450}
+  - {fileID: 70628847}
+  - {fileID: 1270877303}
+  - {fileID: 745154071}
+  - {fileID: 1356154759}
+  - {fileID: 569232123}
+  - {fileID: 261949984}
+  - {fileID: 1837246515}
+  - {fileID: 998852610}
+  - {fileID: 417777434}
+  - {fileID: 531606096}
+  - {fileID: 25881321}
+  - {fileID: 1892315349}
+  - {fileID: 1376430228}
+  - {fileID: 975471614}
+  - {fileID: 949560577}
+  - {fileID: 1055096887}
+  - {fileID: 1259629121}
+  - {fileID: 1179164401}
+  - {fileID: 1837989429}
+  - {fileID: 466475494}
+  - {fileID: 1371245909}
+  - {fileID: 108376951}
+  - {fileID: 1814254251}
+  - {fileID: 883933797}
+  - {fileID: 1751642076}
+  - {fileID: 708313241}
+  - {fileID: 2013534730}
+  - {fileID: 2087984152}
+  - {fileID: 1440940004}
+  - {fileID: 2142612331}
+  - {fileID: 2094990718}
+  - {fileID: 1879778975}
+  - {fileID: 1427107418}
+  - {fileID: 1546381381}
+  - {fileID: 783572360}
+  - {fileID: 1878608646}
+  - {fileID: 1311301817}
+  - {fileID: 1241980233}
+  - {fileID: 2067220331}
+  - {fileID: 702612011}
+  - {fileID: 17868656}
+  - {fileID: 530957441}
+  - {fileID: 2116387897}
+  - {fileID: 1174254732}
+  - {fileID: 813030337}
+  - {fileID: 1553444547}
+  - {fileID: 1954145112}
+  - {fileID: 220138562}
+  - {fileID: 126705777}
+  - {fileID: 1605303584}
+  - {fileID: 1469436229}
+  - {fileID: 1077498933}
+  - {fileID: 2060731880}
+  - {fileID: 2065589677}
+  - {fileID: 1523166802}
+  - {fileID: 1880705473}
+  - {fileID: 1307153501}
+  - {fileID: 273032723}
+  - {fileID: 438705026}
+  - {fileID: 989907369}
+  - {fileID: 1247998485}
+  - {fileID: 1552600068}
+  m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &524802058
-MonoBehaviour:
+--- !u!1001 &530957440
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 524802056}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: NirnsDeep
---- !u!1 &531894052
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 531894053}
-  - component: {fileID: 531894054}
-  m_Layer: 0
-  m_Name: Quiesce
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &531894053
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 531894052}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 15, y: 35, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &531894054
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 531894052}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Quiesce
---- !u!1 &532524362
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 532524363}
-  - component: {fileID: 532524364}
-  m_Layer: 0
-  m_Name: Gildenhome
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &532524363
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Meneloth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 67
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 117
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Meneloth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &530957441 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 532524362}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 33, y: 29, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &532524364
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 532524362}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Gildenhome
---- !u!1 &542569647
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 542569648}
-  - component: {fileID: 542569649}
-  m_Layer: 0
-  m_Name: Upbourne
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &542569648
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 542569647}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 11, y: 91, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &542569649
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 542569647}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Upbourne
---- !u!4 &546283580 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3274794878898324038, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 3274794878370800250}
+  m_PrefabInstance: {fileID: 530957440}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &550150958
+--- !u!1001 &531606095
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Dunethel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 83
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Dunethel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &531606096 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 531606095}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &542280877
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2792,44 +3445,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 550150959}
-  - component: {fileID: 550150960}
+  - component: {fileID: 542280878}
+  - component: {fileID: 542280879}
   m_Layer: 0
-  m_Name: S17W-50
+  m_Name: S17W-35
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &550150959
+--- !u!4 &542280878
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 550150958}
+  m_GameObject: {fileID: 542280877}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 112, z: 0}
+  m_LocalPosition: {x: 67, y: 14, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &550150960
+--- !u!114 &542280879
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 550150958}
+  m_GameObject: {fileID: 542280877}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-50
-  mapByteOffset: 9528
+  siteAnchorId: S17W-35
+  mapByteOffset: 30872
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -2837,7 +3490,13 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &561911661
+--- !u!4 &546283580 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3274794878898324038, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
+    type: 3}
+  m_PrefabInstance: {fileID: 3274794878370800250}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &552500930
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2845,44 +3504,52 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 561911662}
-  - component: {fileID: 561911663}
+  - component: {fileID: 552500931}
+  - component: {fileID: 552500932}
   m_Layer: 0
-  m_Name: TempleofIris
+  m_Name: S17W-02
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &561911662
+--- !u!4 &552500931
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 561911661}
+  m_GameObject: {fileID: 552500930}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 45, y: 125, z: 0}
+  m_LocalPosition: {x: 5, y: 132, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &561911663
+--- !u!114 &552500932
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 561911661}
+  m_GameObject: {fileID: 552500930}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TempleofIris
---- !u!1 &567069389
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-02
+  mapByteOffset: 5024
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &562312098
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2890,43 +3557,209 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 567069390}
-  - component: {fileID: 567069391}
+  - component: {fileID: 562312099}
+  - component: {fileID: 562312100}
   m_Layer: 0
-  m_Name: RuinsofHaviel
+  m_Name: S17W-59
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &567069390
+--- !u!4 &562312099
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 567069389}
+  m_GameObject: {fileID: 562312098}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 34, y: 10, z: 0}
+  m_LocalPosition: {x: 92, y: 125, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &567069391
+--- !u!114 &562312100
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 567069389}
+  m_GameObject: {fileID: 562312098}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: RuinsofHaviel
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-59
+  mapByteOffset: 6724
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &568907617
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 30.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: TowerofNight
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: TowerofNight
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &568907618 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 568907617}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &569232122
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Ubar
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 69
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Ubar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &569232123 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 569232122}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &572604740 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3274794878943241022, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
@@ -2939,202 +3772,164 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: af7e80bce9c65884dace92099102a361, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &584810792
-GameObject:
+--- !u!1001 &572843664
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 584810793}
-  - component: {fileID: 584810794}
-  m_Layer: 0
-  m_Name: S17W-40
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &584810793
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 584810792}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 112, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &584810794
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 584810792}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-40
-  mapByteOffset: 9518
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &600952121
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 600952122}
-  - component: {fileID: 600952123}
-  m_Layer: 0
-  m_Name: S17W-53
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &600952122
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Kor
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Kor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &572843665 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 572843664}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 600952121}
+--- !u!1001 &609163787
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 88, y: 112, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &600952123
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 600952121}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-53
-  mapByteOffset: 9550
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &608557870
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 608557871}
-  - component: {fileID: 608557872}
-  m_Layer: 0
-  m_Name: GrandOracle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &608557871
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 93.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 87.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DragontowerRuins
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DragontowerRuins
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &609163788 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 609163787}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 608557870}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 21, y: 131, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &608557872
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 608557870}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: GrandOracle
---- !u!1 &608723662
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 608723663}
-  - component: {fileID: 608723664}
-  m_Layer: 0
-  m_Name: Gemhold
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &608723663
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 608723662}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 66, y: 53, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &608723664
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 608723662}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: Gemhold
 --- !u!1 &612679814
 GameObject:
   m_ObjectHideFlags: 0
@@ -3252,7 +4047,7 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 612679814}
   m_CullTransparentMesh: 1
---- !u!1 &617124375
+--- !u!1 &615101243
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3260,224 +4055,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 617124376}
-  - component: {fileID: 617124377}
+  - component: {fileID: 615101244}
+  - component: {fileID: 615101245}
   m_Layer: 0
-  m_Name: GiantsTomb
+  m_Name: S17W-21
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &617124376
+--- !u!4 &615101244
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 617124375}
+  m_GameObject: {fileID: 615101243}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 33, y: 74, z: 0}
+  m_LocalPosition: {x: 40, y: 74, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &617124377
+--- !u!114 &615101245
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 617124375}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: GiantsTomb
---- !u!1 &672549730
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 672549731}
-  - component: {fileID: 672549732}
-  m_Layer: 0
-  m_Name: Marthos
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &672549731
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 672549730}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 62, y: 11, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &672549732
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 672549730}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Marthos
---- !u!1 &679993737
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 679993738}
-  - component: {fileID: 679993739}
-  m_Layer: 0
-  m_Name: Lador
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &679993738
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 679993737}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 31, y: 49, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &679993739
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 679993737}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Lador
---- !u!1 &693081615
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 693081616}
-  - component: {fileID: 693081617}
-  m_Layer: 0
-  m_Name: Guardian
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &693081616
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 693081615}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 100, y: 46, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &693081617
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 693081615}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: Guardian
---- !u!1 &706648924
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 706648925}
-  - component: {fileID: 706648926}
-  m_Layer: 0
-  m_Name: S17W-13
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &706648925
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 706648924}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 22, y: 28, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &706648926
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 706648924}
+  m_GameObject: {fileID: 615101243}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-13
-  mapByteOffset: 27730
+  siteAnchorId: S17W-21
+  mapByteOffset: 17738
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -3485,7 +4100,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &743238304
+--- !u!1001 &628227964
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Kazrak
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 58
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Kazrak
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &628227965 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 628227964}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &642682789
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3493,179 +4187,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 743238305}
-  - component: {fileID: 743238306}
+  - component: {fileID: 642682790}
+  - component: {fileID: 642682791}
   m_Layer: 0
-  m_Name: TombofNaar
+  m_Name: S17W-40
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &743238305
+--- !u!4 &642682790
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 743238304}
+  m_GameObject: {fileID: 642682789}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 94, y: 33, z: 0}
+  m_LocalPosition: {x: 72, y: 112, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &743238306
+--- !u!114 &642682791
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 743238304}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TombofNaar
---- !u!1 &746945410
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 746945411}
-  - component: {fileID: 746945412}
-  m_Layer: 0
-  m_Name: CitadelofFire
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &746945411
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 746945410}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 59, y: 73, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &746945412
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 746945410}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: CitadelofFire
---- !u!1 &755907679
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 755907680}
-  - component: {fileID: 755907681}
-  m_Layer: 0
-  m_Name: Vival
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &755907680
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 755907679}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 6, y: 135, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &755907681
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 755907679}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Vival
---- !u!1 &760134422
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 760134423}
-  - component: {fileID: 760134424}
-  m_Layer: 0
-  m_Name: S17W-31
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &760134423
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 760134422}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57, y: 22, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &760134424
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 760134422}
+  m_GameObject: {fileID: 642682789}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-31
-  mapByteOffset: 29108
+  siteAnchorId: S17W-40
+  mapByteOffset: 9518
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -3673,7 +4232,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &768010708
+--- !u!1001 &645376915
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 76.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 114.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DragonHalls
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DragonHalls
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &645376916 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 645376915}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &647529785
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3681,44 +4319,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 768010709}
-  - component: {fileID: 768010710}
+  - component: {fileID: 647529786}
+  - component: {fileID: 647529787}
   m_Layer: 0
-  m_Name: S17W-51
+  m_Name: S17W-61
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &768010709
+--- !u!4 &647529786
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 768010708}
+  m_GameObject: {fileID: 647529785}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 81, y: 59, z: 0}
+  m_LocalPosition: {x: 93, y: 56, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &768010710
+--- !u!114 &647529787
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 768010708}
+  m_GameObject: {fileID: 647529785}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-51
-  mapByteOffset: 21090
+  siteAnchorId: S17W-61
+  mapByteOffset: 21768
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -3726,7 +4364,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &770560151
+--- !u!1001 &651858884
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 86.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 105.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: HallsofChaos
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: HallsofChaos
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &651858885 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 651858884}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &655109381
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3734,44 +4451,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 770560152}
-  - component: {fileID: 770560153}
+  - component: {fileID: 655109382}
+  - component: {fileID: 655109383}
   m_Layer: 0
-  m_Name: S17W-48
+  m_Name: S17W-38
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &770560152
+--- !u!4 &655109382
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 770560151}
+  m_GameObject: {fileID: 655109381}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 142, z: 0}
+  m_LocalPosition: {x: 70, y: 18, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &770560153
+--- !u!114 &655109383
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 770560151}
+  m_GameObject: {fileID: 655109381}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-48
-  mapByteOffset: 2988
+  siteAnchorId: S17W-38
+  mapByteOffset: 30006
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -3779,7 +4496,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &791215943
+--- !u!1 &673920028
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3787,44 +4504,289 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 791215944}
-  - component: {fileID: 791215945}
+  - component: {fileID: 673920029}
+  - component: {fileID: 673920030}
   m_Layer: 0
-  m_Name: Kazrak
+  m_Name: S17W-03
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &791215944
+--- !u!4 &673920029
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 791215943}
+  m_GameObject: {fileID: 673920028}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 58, y: 64, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_LocalPosition: {x: 7, y: 152, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1000689320}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &791215945
+--- !u!114 &673920030
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 791215943}
+  m_GameObject: {fileID: 673920028}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Kazrak
---- !u!1 &799516030
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-03
+  mapByteOffset: 668
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &700803660
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: ThroneofHoran
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: ThroneofHoran
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &700803661 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 700803660}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &702612010
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Darclan
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 99
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Darclan
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &702612011 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 702612010}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &708313240
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Dethal
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 98
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 103
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Dethal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &708313241 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 708313240}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &732485646
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3832,44 +4794,684 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 799516031}
-  - component: {fileID: 799516032}
+  - component: {fileID: 732485647}
+  - component: {fileID: 732485648}
   m_Layer: 0
-  m_Name: Carmel
+  m_Name: S17W-53
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &799516031
+--- !u!4 &732485647
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 799516030}
+  m_GameObject: {fileID: 732485646}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 19, y: 84, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_LocalPosition: {x: 88, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1000689320}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &799516032
+--- !u!114 &732485648
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 799516030}
+  m_GameObject: {fileID: 732485646}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Carmel
---- !u!1 &802442924
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-53
+  mapByteOffset: 9550
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &737233882
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 38.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 62.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: GreatLibrary
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: GreatLibrary
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &737233883 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 737233882}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &745154070
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Deephallow
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 124
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Deephallow
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &745154071 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 745154070}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &771466588
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Varde
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Varde
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &771466589 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 771466588}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &779035664
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Vival
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 135
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Vival
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &779035665 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 779035664}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &783572359
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gimlad
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 89
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 67
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gimlad
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &783572360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 783572359}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &804887380
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 55.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 119.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: NirnsDeep
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: NirnsDeep
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &804887381 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 804887380}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &813030336
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Fleymark
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 81
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Fleymark
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &813030337 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 813030336}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &814302602
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: PaKur
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 86
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: PaKur
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &814302603 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 814302602}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &818195350
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3877,7 +5479,7 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 802442925}
+  - component: {fileID: 818195351}
   m_Layer: 0
   m_Name: SiteAnchors
   m_TagString: Untagged
@@ -3885,86 +5487,165 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &802442925
+--- !u!4 &818195351
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 802442924}
+  m_GameObject: {fileID: 818195350}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1578618460}
-  - {fileID: 281377096}
-  - {fileID: 1238226526}
-  - {fileID: 1932770635}
-  - {fileID: 1687503150}
-  - {fileID: 65750853}
-  - {fileID: 1867166145}
-  - {fileID: 1950118309}
-  - {fileID: 1772214044}
-  - {fileID: 926641884}
-  - {fileID: 108245969}
-  - {fileID: 1348053793}
-  - {fileID: 706648925}
-  - {fileID: 1679469666}
-  - {fileID: 273204886}
-  - {fileID: 1069064360}
-  - {fileID: 1787075040}
-  - {fileID: 1310152244}
-  - {fileID: 1290561148}
-  - {fileID: 1120073078}
-  - {fileID: 1224575328}
-  - {fileID: 1236887574}
-  - {fileID: 1891619822}
-  - {fileID: 494074086}
-  - {fileID: 1554759105}
-  - {fileID: 1487680118}
-  - {fileID: 1189443759}
-  - {fileID: 514582119}
-  - {fileID: 1375387432}
-  - {fileID: 1115395459}
-  - {fileID: 760134423}
-  - {fileID: 1370736036}
-  - {fileID: 873783515}
-  - {fileID: 1339294173}
-  - {fileID: 170837495}
-  - {fileID: 877277467}
-  - {fileID: 1256598448}
-  - {fileID: 455852678}
-  - {fileID: 2094547022}
-  - {fileID: 584810793}
-  - {fileID: 476688042}
-  - {fileID: 828033483}
-  - {fileID: 991737911}
-  - {fileID: 1946767549}
-  - {fileID: 933447608}
-  - {fileID: 1121522342}
-  - {fileID: 931071160}
-  - {fileID: 770560152}
-  - {fileID: 232725004}
-  - {fileID: 550150959}
-  - {fileID: 768010709}
-  - {fileID: 1306376687}
-  - {fileID: 600952122}
-  - {fileID: 74526221}
-  - {fileID: 833235508}
-  - {fileID: 1974692416}
-  - {fileID: 191204432}
-  - {fileID: 2139704567}
-  - {fileID: 1644485418}
-  - {fileID: 1209452484}
-  - {fileID: 1432629152}
-  - {fileID: 1489550085}
-  - {fileID: 1049789766}
-  - {fileID: 507540974}
+  - {fileID: 1337929245}
+  - {fileID: 552500931}
+  - {fileID: 673920029}
+  - {fileID: 1321070472}
+  - {fileID: 908796586}
+  - {fileID: 1923041882}
+  - {fileID: 2086883951}
+  - {fileID: 2051036623}
+  - {fileID: 1829056166}
+  - {fileID: 1792841183}
+  - {fileID: 1577780678}
+  - {fileID: 498158720}
+  - {fileID: 1108912329}
+  - {fileID: 128346275}
+  - {fileID: 1638157248}
+  - {fileID: 1419864815}
+  - {fileID: 1969623974}
+  - {fileID: 482302819}
+  - {fileID: 1114565599}
+  - {fileID: 1223500151}
+  - {fileID: 615101244}
+  - {fileID: 1916110663}
+  - {fileID: 2132718336}
+  - {fileID: 274702071}
+  - {fileID: 386410572}
+  - {fileID: 205536471}
+  - {fileID: 992645251}
+  - {fileID: 242299945}
+  - {fileID: 287395396}
+  - {fileID: 1839947480}
+  - {fileID: 209138480}
+  - {fileID: 955578233}
+  - {fileID: 958970827}
+  - {fileID: 1727064488}
+  - {fileID: 542280878}
+  - {fileID: 1235820162}
+  - {fileID: 466131451}
+  - {fileID: 655109382}
+  - {fileID: 501127553}
+  - {fileID: 642682790}
+  - {fileID: 1874487367}
+  - {fileID: 81254370}
+  - {fileID: 857805142}
+  - {fileID: 1405312980}
+  - {fileID: 458103045}
+  - {fileID: 1267698130}
+  - {fileID: 1488393897}
+  - {fileID: 1875173423}
+  - {fileID: 1464920109}
+  - {fileID: 987054033}
+  - {fileID: 1660598210}
+  - {fileID: 1281269319}
+  - {fileID: 732485647}
+  - {fileID: 204114862}
+  - {fileID: 1457457847}
+  - {fileID: 1447443200}
+  - {fileID: 1491074898}
+  - {fileID: 982258805}
+  - {fileID: 562312099}
+  - {fileID: 1331182061}
+  - {fileID: 647529786}
+  - {fileID: 865407175}
+  - {fileID: 985301253}
+  - {fileID: 1080371608}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &815853886
+--- !u!1001 &828835893
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Tasme
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Tasme
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &828835894 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 828835893}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &857805141
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3972,205 +5653,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 815853887}
+  - component: {fileID: 857805142}
+  - component: {fileID: 857805143}
   m_Layer: 0
-  m_Name: Locations
+  m_Name: S17W-43
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &815853887
+--- !u!4 &857805142
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 815853886}
+  m_GameObject: {fileID: 857805141}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 561911662}
-  - {fileID: 11935019}
-  - {fileID: 835223136}
-  - {fileID: 140661882}
-  - {fileID: 41186227}
-  - {fileID: 1369184871}
-  - {fileID: 14100627}
-  - {fileID: 608557871}
-  - {fileID: 104509488}
-  - {fileID: 895256791}
-  - {fileID: 1333623142}
-  - {fileID: 1936336609}
-  - {fileID: 1389114154}
-  - {fileID: 1543818224}
-  - {fileID: 1744529939}
-  - {fileID: 524802057}
-  - {fileID: 1672326516}
-  - {fileID: 1112486252}
-  - {fileID: 984108424}
-  - {fileID: 866772962}
-  - {fileID: 2063296263}
-  - {fileID: 285019230}
-  - {fileID: 1642929336}
-  - {fileID: 1052697789}
-  - {fileID: 1585880402}
-  - {fileID: 881372459}
-  - {fileID: 1934986032}
-  - {fileID: 617124376}
-  - {fileID: 1190494761}
-  - {fileID: 567069390}
-  - {fileID: 2020993015}
-  - {fileID: 1910667175}
-  - {fileID: 608723663}
-  - {fileID: 1647803128}
-  - {fileID: 1654481005}
-  - {fileID: 693081616}
-  - {fileID: 2077732291}
-  - {fileID: 1288277093}
-  - {fileID: 743238305}
-  - {fileID: 393786954}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &826186167
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 826186168}
-  - component: {fileID: 826186169}
-  m_Layer: 0
-  m_Name: Minbourne
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &826186168
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 826186167}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 70, y: 148, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &826186169
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 826186167}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Minbourne
---- !u!1 &827716870
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 827716871}
-  - component: {fileID: 827716872}
-  m_Layer: 0
-  m_Name: Marton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &827716871
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 827716870}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 18, y: 109, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &827716872
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 827716870}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Marton
---- !u!1 &828033482
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 828033483}
-  - component: {fileID: 828033484}
-  m_Layer: 0
-  m_Name: S17W-42
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &828033483
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 828033482}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 37, z: 0}
+  m_LocalPosition: {x: 72, y: 26, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &828033484
+--- !u!114 &857805143
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 828033482}
+  m_GameObject: {fileID: 857805141}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-42
-  mapByteOffset: 25868
+  siteAnchorId: S17W-43
+  mapByteOffset: 28266
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -4178,7 +5698,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &833235507
+--- !u!1001 &865215781
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 100.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 93.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: CryptofMolok
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: CryptofMolok
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &865215782 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 865215781}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &865407174
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4186,44 +5785,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 833235508}
-  - component: {fileID: 833235509}
+  - component: {fileID: 865407175}
+  - component: {fileID: 865407176}
   m_Layer: 0
-  m_Name: S17W-55
+  m_Name: S17W-62
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &833235508
+--- !u!4 &865407175
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 833235507}
+  m_GameObject: {fileID: 865407174}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 90, y: 43, z: 0}
+  m_LocalPosition: {x: 95, y: 139, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &833235509
+--- !u!114 &865407176
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 833235507}
+  m_GameObject: {fileID: 865407174}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-55
-  mapByteOffset: 24596
+  siteAnchorId: S17W-62
+  mapByteOffset: 3678
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -4231,7 +5830,165 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &835223135
+--- !u!1001 &883933796
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Ilnyr
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 71
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 61
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Ilnyr
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &883933797 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 883933796}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &885622283
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 45.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: NirnsCrypt
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: NirnsCrypt
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &885622284 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 885622283}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &908796585
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4239,134 +5996,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 835223136}
-  - component: {fileID: 835223137}
+  - component: {fileID: 908796586}
+  - component: {fileID: 908796587}
   m_Layer: 0
-  m_Name: TempleofEmrik
+  m_Name: S17W-05
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &835223136
+--- !u!4 &908796586
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 835223135}
+  m_GameObject: {fileID: 908796585}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 102, y: 154, z: 0}
+  m_LocalPosition: {x: 14, y: 31, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &835223137
+--- !u!114 &908796587
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 835223135}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TempleofEmrik
---- !u!1 &866772961
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 866772962}
-  - component: {fileID: 866772963}
-  m_Layer: 0
-  m_Name: Bridgetower
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &866772962
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 866772961}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 92, y: 149, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &866772963
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 866772961}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: Bridgetower
---- !u!1 &873783514
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 873783515}
-  - component: {fileID: 873783516}
-  m_Layer: 0
-  m_Name: S17W-33
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &873783515
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 873783514}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 63, y: 44, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &873783516
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 873783514}
+  m_GameObject: {fileID: 908796585}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-33
-  mapByteOffset: 24324
+  siteAnchorId: S17W-05
+  mapByteOffset: 27060
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -4374,398 +6041,85 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &877277466
-GameObject:
+--- !u!1001 &941280968
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 877277467}
-  - component: {fileID: 877277468}
-  m_Layer: 0
-  m_Name: S17W-36
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &877277467
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 877277466}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 70, y: 99, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &877277468
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 877277466}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-36
-  mapByteOffset: 12348
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &881372458
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 881372459}
-  - component: {fileID: 881372460}
-  m_Layer: 0
-  m_Name: ThroneofHoran
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &881372459
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 29.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 131.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: OldWoodsTower
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: OldWoodsTower
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &941280969 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 941280968}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 881372458}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 18, y: 22, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &881372460
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 881372458}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: ThroneofHoran
---- !u!1 &895256790
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 895256791}
-  - component: {fileID: 895256792}
-  m_Layer: 0
-  m_Name: EmperorsCrypt
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &895256791
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 895256790}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 18, y: 102, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &895256792
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 895256790}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: EmperorsCrypt
---- !u!1 &920705772
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 920705773}
-  - component: {fileID: 920705774}
-  m_Layer: 0
-  m_Name: Barthel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &920705773
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 920705772}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 32, y: 114, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &920705774
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 920705772}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Barthel
---- !u!1 &926055304
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 926055305}
-  - component: {fileID: 926055306}
-  m_Layer: 0
-  m_Name: Dethal
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &926055305
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926055304}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 98, y: 103, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &926055306
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926055304}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Dethal
---- !u!1 &926641883
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 926641884}
-  - component: {fileID: 926641885}
-  m_Layer: 0
-  m_Name: S17W-10
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &926641884
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926641883}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 19, y: 117, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &926641885
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 926641883}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-10
-  mapByteOffset: 8322
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &931071159
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 931071160}
-  - component: {fileID: 931071161}
-  m_Layer: 0
-  m_Name: S17W-47
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &931071160
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 931071159}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 144, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &931071161
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 931071159}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-47
-  mapByteOffset: 2552
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &933447607
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 933447608}
-  - component: {fileID: 933447609}
-  m_Layer: 0
-  m_Name: S17W-45
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &933447608
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 933447607}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 73, y: 32, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &933447609
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 933447607}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-45
-  mapByteOffset: 26960
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
 --- !u!1 &943228520
 GameObject:
   m_ObjectHideFlags: 0
@@ -4845,7 +6199,244 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 943228520}
   m_CullTransparentMesh: 1
---- !u!1 &944160560
+--- !u!1001 &949560576
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: CitadelofIce
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 63
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: CitadelofIce
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &949560577 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 949560576}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &953755985
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 72.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 98.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: SeeroftheRiver
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: SeeroftheRiver
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &953755986 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 953755985}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &955276894
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 57.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 74.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DarkBarrows
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DarkBarrows
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &955276895 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 955276894}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &955578232
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -4853,314 +6444,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 944160561}
-  - component: {fileID: 944160562}
+  - component: {fileID: 955578233}
+  - component: {fileID: 955578234}
   m_Layer: 0
-  m_Name: Varde
+  m_Name: S17W-32
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &944160561
+--- !u!4 &955578233
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 944160560}
+  m_GameObject: {fileID: 955578232}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8, y: 33, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &944160562
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 944160560}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Varde
---- !u!1 &947468197
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 947468198}
-  - component: {fileID: 947468199}
-  m_Layer: 0
-  m_Name: Thurtz
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &947468198
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 947468197}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 85, y: 65, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &947468199
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 947468197}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Thurtz
---- !u!1 &959786203
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 959786204}
-  - component: {fileID: 959786205}
-  m_Layer: 0
-  m_Name: AlfarsGap
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &959786204
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 959786203}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 22, y: 13, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &959786205
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 959786203}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: AlfarsGap
---- !u!1 &970451121
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 970451122}
-  - component: {fileID: 970451123}
-  m_Layer: 0
-  m_Name: Tirfing
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &970451122
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 970451121}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 68, y: 143, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &970451123
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 970451121}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Tirfing
---- !u!1 &982653229
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 982653230}
-  - component: {fileID: 982653231}
-  m_Layer: 0
-  m_Name: Herzag
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &982653230
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 982653229}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 78, y: 67, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &982653231
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 982653229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Herzag
---- !u!1 &984108423
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 984108424}
-  - component: {fileID: 984108425}
-  m_Layer: 0
-  m_Name: DragonHalls
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &984108424
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984108423}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 76, y: 114, z: 0}
+  m_LocalPosition: {x: 60, y: 14, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &984108425
+--- !u!114 &955578234
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 984108423}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: DragonHalls
---- !u!1 &991737910
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 991737911}
-  - component: {fileID: 991737912}
-  m_Layer: 0
-  m_Name: S17W-43
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &991737911
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 991737910}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 26, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &991737912
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 991737910}
+  m_GameObject: {fileID: 955578232}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-43
-  mapByteOffset: 28266
+  siteAnchorId: S17W-32
+  mapByteOffset: 30858
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -5168,7 +6489,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1000689319
+--- !u!1 &958970826
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5176,109 +6497,574 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1000689320}
+  - component: {fileID: 958970827}
+  - component: {fileID: 958970828}
   m_Layer: 0
-  m_Name: Cities
+  m_Name: S17W-33
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1000689320
+--- !u!4 &958970827
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1000689319}
+  m_GameObject: {fileID: 958970826}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 63, y: 44, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 524239830}
-  - {fileID: 127820317}
-  - {fileID: 944160561}
-  - {fileID: 1487992548}
-  - {fileID: 1484261411}
-  - {fileID: 1615586698}
-  - {fileID: 1995627666}
-  - {fileID: 1038591476}
-  - {fileID: 1432206041}
-  - {fileID: 1500113119}
-  - {fileID: 98160895}
-  - {fileID: 791215944}
-  - {fileID: 1035346395}
-  - {fileID: 755907680}
-  - {fileID: 982653230}
-  - {fileID: 799516031}
-  - {fileID: 1881936021}
-  - {fileID: 679993738}
-  - {fileID: 1583966527}
-  - {fileID: 480800641}
-  - {fileID: 38491915}
-  - {fileID: 1845695330}
-  - {fileID: 1979117230}
-  - {fileID: 827716871}
-  - {fileID: 1053449671}
-  - {fileID: 281114112}
-  - {fileID: 1635037804}
-  - {fileID: 1668124583}
-  - {fileID: 1842900927}
-  - {fileID: 947468198}
-  - {fileID: 2102389403}
-  - {fileID: 1304985206}
-  - {fileID: 1064125232}
-  - {fileID: 826186168}
-  - {fileID: 920705773}
-  - {fileID: 532524363}
-  - {fileID: 156299711}
-  - {fileID: 1845318796}
-  - {fileID: 431364162}
-  - {fileID: 1900865273}
-  - {fileID: 1426471404}
-  - {fileID: 213843997}
-  - {fileID: 1132815075}
-  - {fileID: 926055305}
-  - {fileID: 1898256569}
-  - {fileID: 63543186}
-  - {fileID: 2116115537}
-  - {fileID: 1169194025}
-  - {fileID: 1381243202}
-  - {fileID: 35647829}
-  - {fileID: 1555886813}
-  - {fileID: 542569648}
-  - {fileID: 1648774070}
-  - {fileID: 1867916651}
-  - {fileID: 1400237182}
-  - {fileID: 488372532}
-  - {fileID: 1949247052}
-  - {fileID: 1807414438}
-  - {fileID: 2035740380}
-  - {fileID: 427689074}
-  - {fileID: 505423197}
-  - {fileID: 249791408}
-  - {fileID: 1757483317}
-  - {fileID: 746945411}
-  - {fileID: 959786204}
-  - {fileID: 379460441}
-  - {fileID: 356132682}
-  - {fileID: 1485415819}
-  - {fileID: 1380952434}
-  - {fileID: 1882091840}
-  - {fileID: 1938284326}
-  - {fileID: 1385896681}
-  - {fileID: 1844045151}
-  - {fileID: 1811749617}
-  - {fileID: 1898582765}
-  - {fileID: 531894053}
-  - {fileID: 970451122}
-  - {fileID: 672549731}
-  - {fileID: 2030235217}
-  - {fileID: 1240331531}
-  m_Father: {fileID: 0}
+  m_Children: []
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &958970828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 958970826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-33
+  mapByteOffset: 24324
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &975471613
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Zhoran
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 93
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Zhoran
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &975471614 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 975471613}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &982258804
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 982258805}
+  - component: {fileID: 982258806}
+  m_Layer: 0
+  m_Name: S17W-58
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &982258805
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982258804}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 91, y: 45, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &982258806
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 982258804}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-58
+  mapByteOffset: 24162
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &985301252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 985301253}
+  - component: {fileID: 985301254}
+  m_Layer: 0
+  m_Name: S17W-63
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &985301253
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 985301252}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 95, y: 65, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &985301254
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 985301252}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-63
+  mapByteOffset: 19810
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &987054032
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 987054033}
+  - component: {fileID: 987054034}
+  m_Layer: 0
+  m_Name: S17W-50
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &987054033
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 987054032}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 77, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &987054034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 987054032}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-50
+  mapByteOffset: 9528
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &989907368
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 62
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Marthos
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &989907369 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 989907368}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &992645250
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 992645251}
+  - component: {fileID: 992645252}
+  m_Layer: 0
+  m_Name: S17W-27
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &992645251
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 992645250}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 54, y: 54, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &992645252
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 992645250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-27
+  mapByteOffset: 22126
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &998852609
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Garom
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Garom
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &998852610 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 998852609}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1026372773
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 82.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 38.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: CryptofBaal
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: CryptofBaal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1026372774 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1026372773}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1031883957
 GameObject:
   m_ObjectHideFlags: 0
@@ -5354,7 +7140,165 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1031883957}
   m_CullTransparentMesh: 1
---- !u!1 &1035346394
+--- !u!1001 &1055096886
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Minbourne
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 148
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Minbourne
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1055096887 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1055096886}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1077498932
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Galin
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 67
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Galin
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1077498933 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1077498932}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1080371607
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5362,134 +7306,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1035346395}
-  - component: {fileID: 1035346396}
+  - component: {fileID: 1080371608}
+  - component: {fileID: 1080371609}
   m_Layer: 0
-  m_Name: Kor
+  m_Name: S17W-64
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1035346395
+--- !u!4 &1080371608
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1035346394}
+  m_GameObject: {fileID: 1080371607}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 100, y: 64, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1035346396
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1035346394}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Kor
---- !u!1 &1038591475
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1038591476}
-  - component: {fileID: 1038591477}
-  m_Layer: 0
-  m_Name: Wellmore
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1038591476
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1038591475}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4, y: 51, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1038591477
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1038591475}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Wellmore
---- !u!1 &1049789765
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1049789766}
-  - component: {fileID: 1049789767}
-  m_Layer: 0
-  m_Name: S17W-63
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1049789766
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1049789765}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 95, y: 65, z: 0}
+  m_LocalPosition: {x: 97, y: 115, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1049789767
+--- !u!114 &1080371609
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1049789765}
+  m_GameObject: {fileID: 1080371607}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-63
-  mapByteOffset: 19810
+  siteAnchorId: S17W-64
+  mapByteOffset: 8914
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -5497,7 +7351,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1052697788
+--- !u!1001 &1083960862
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 101.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: HarvestStone
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: HarvestStone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1083960863 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1083960862}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1108912328
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5505,179 +7438,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1052697789}
-  - component: {fileID: 1052697790}
+  - component: {fileID: 1108912329}
+  - component: {fileID: 1108912330}
   m_Layer: 0
-  m_Name: NevDolar
+  m_Name: S17W-13
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1052697789
+--- !u!4 &1108912329
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1052697788}
+  m_GameObject: {fileID: 1108912328}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 16, y: 56, z: 0}
+  m_LocalPosition: {x: 22, y: 28, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1052697790
+--- !u!114 &1108912330
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1052697788}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: NevDolar
---- !u!1 &1053449670
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1053449671}
-  - component: {fileID: 1053449672}
-  m_Layer: 0
-  m_Name: Gork
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1053449671
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1053449670}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 86, y: 22, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1053449672
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1053449670}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Gork
---- !u!1 &1064125231
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1064125232}
-  - component: {fileID: 1064125233}
-  m_Layer: 0
-  m_Name: CitadelofIce
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1064125232
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1064125231}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 63, y: 73, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1064125233
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1064125231}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: CitadelofIce
---- !u!1 &1069064359
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1069064360}
-  - component: {fileID: 1069064361}
-  m_Layer: 0
-  m_Name: S17W-16
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1069064360
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1069064359}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 27, y: 54, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1069064361
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1069064359}
+  m_GameObject: {fileID: 1108912328}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-16
-  mapByteOffset: 22072
+  siteAnchorId: S17W-13
+  mapByteOffset: 27730
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -5685,7 +7483,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1112486251
+--- !u!1 &1114565598
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -5693,89 +7491,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1112486252}
-  - component: {fileID: 1112486253}
+  - component: {fileID: 1114565599}
+  - component: {fileID: 1114565600}
   m_Layer: 0
-  m_Name: WizardsHearth
+  m_Name: S17W-19
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1112486252
+--- !u!4 &1114565599
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1112486251}
+  m_GameObject: {fileID: 1114565598}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 68, y: 89, z: 0}
+  m_LocalPosition: {x: 38, y: 111, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1112486253
+--- !u!114 &1114565600
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1112486251}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: WizardsHearth
---- !u!1 &1115395458
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1115395459}
-  - component: {fileID: 1115395460}
-  m_Layer: 0
-  m_Name: S17W-30
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1115395459
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1115395458}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57, y: 29, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1115395460
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1115395458}
+  m_GameObject: {fileID: 1114565598}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-30
-  mapByteOffset: 27582
+  siteAnchorId: S17W-19
+  mapByteOffset: 9668
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -5783,300 +7536,322 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1120073077
-GameObject:
+--- !u!1001 &1125684619
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1120073078}
-  - component: {fileID: 1120073079}
-  m_Layer: 0
-  m_Name: S17W-20
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1120073078
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1120073077}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 38, y: 88, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1120073079
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1120073077}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-20
-  mapByteOffset: 14682
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1121522341
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1121522342}
-  - component: {fileID: 1121522343}
-  m_Layer: 0
-  m_Name: S17W-46
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1121522342
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: AkEnlie
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: AkEnlie
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1125684620 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1125684619}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1121522341}
+--- !u!1001 &1174254731
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 73, y: 29, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1121522343
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1121522341}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-46
-  mapByteOffset: 27614
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1132815074
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1132815075}
-  - component: {fileID: 1132815076}
-  m_Layer: 0
-  m_Name: Upway
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1132815075
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Malikor
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 98
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 117
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Malikor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1174254732 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1174254731}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1132815074}
+--- !u!1001 &1175321532
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 46, y: 101, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1132815076
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1132815074}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Upway
---- !u!1 &1169194024
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1169194025}
-  - component: {fileID: 1169194026}
-  m_Layer: 0
-  m_Name: Troy
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1169194025
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Duinoth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 49
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Duinoth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1175321533 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1175321532}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1169194024}
+--- !u!1001 &1179164400
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 56, y: 40, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1169194026
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1169194024}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Troy
---- !u!1 &1189443758
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1189443759}
-  - component: {fileID: 1189443760}
-  m_Layer: 0
-  m_Name: S17W-27
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1189443759
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gildenhome
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gildenhome
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1179164401 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1179164400}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1189443758}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 54, y: 54, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1189443760
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1189443758}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-27
-  mapByteOffset: 22126
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1190494760
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1190494761}
-  - component: {fileID: 1190494762}
-  m_Layer: 0
-  m_Name: TowerofDeath
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1190494761
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1190494760}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 42, y: 37, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1190494762
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1190494760}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TowerofDeath
 --- !u!850595691 &1200442662
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -6144,7 +7919,165 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
   m_RespectSceneVisibilityWhenBakingGI: 0
---- !u!1 &1209452483
+--- !u!1001 &1200497009
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DuskStone
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DuskStone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1200497010 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1200497009}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1214904167
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Carmel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Carmel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1214904168 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1214904167}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1223500150
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6152,44 +8085,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1209452484}
-  - component: {fileID: 1209452485}
+  - component: {fileID: 1223500151}
+  - component: {fileID: 1223500152}
   m_Layer: 0
-  m_Name: S17W-60
+  m_Name: S17W-20
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1209452484
+--- !u!4 &1223500151
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1209452483}
+  m_GameObject: {fileID: 1223500150}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 92, y: 77, z: 0}
+  m_LocalPosition: {x: 38, y: 88, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1209452485
+--- !u!114 &1223500152
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1209452483}
+  m_GameObject: {fileID: 1223500150}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-60
-  mapByteOffset: 17188
+  siteAnchorId: S17W-20
+  mapByteOffset: 14682
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -6197,7 +8130,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1224575327
+--- !u!1 &1235820161
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6205,44 +8138,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1224575328}
-  - component: {fileID: 1224575329}
+  - component: {fileID: 1235820162}
+  - component: {fileID: 1235820163}
   m_Layer: 0
-  m_Name: S17W-21
+  m_Name: S17W-36
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1224575328
+--- !u!4 &1235820162
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1224575327}
+  m_GameObject: {fileID: 1235820161}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 40, y: 74, z: 0}
+  m_LocalPosition: {x: 70, y: 99, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1224575329
+--- !u!114 &1235820163
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1224575327}
+  m_GameObject: {fileID: 1235820161}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-21
-  mapByteOffset: 17738
+  siteAnchorId: S17W-36
+  mapByteOffset: 12348
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -6250,7 +8183,244 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1236887573
+--- !u!1001 &1241980232
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: AkGiriel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 28
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 123
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: AkGiriel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1241980233 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1241980232}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1247998484
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Tal
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 51
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 148
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Tal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1247998485 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1247998484}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1259629120
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Barthel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 32
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 114
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Barthel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1259629121 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1259629120}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1267698129
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6258,44 +8428,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1236887574}
-  - component: {fileID: 1236887575}
+  - component: {fileID: 1267698130}
+  - component: {fileID: 1267698131}
   m_Layer: 0
-  m_Name: S17W-22
+  m_Name: S17W-46
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1236887574
+--- !u!4 &1267698130
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1236887573}
+  m_GameObject: {fileID: 1267698129}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 49, y: 112, z: 0}
+  m_LocalPosition: {x: 73, y: 29, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1236887575
+--- !u!114 &1267698131
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1236887573}
+  m_GameObject: {fileID: 1267698129}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-22
-  mapByteOffset: 9472
+  siteAnchorId: S17W-46
+  mapByteOffset: 27614
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -6303,158 +8473,165 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1238226525
-GameObject:
+--- !u!1001 &1270877302
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1238226526}
-  - component: {fileID: 1238226527}
-  m_Layer: 0
-  m_Name: S17W-03
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1238226526
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1238226525}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7, y: 152, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1238226527
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1238226525}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-03
-  mapByteOffset: 668
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1240331530
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1240331531}
-  - component: {fileID: 1240331532}
-  m_Layer: 0
-  m_Name: Loremark
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1240331531
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Cragmorton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 89
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Cragmorton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1270877303 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1270877302}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240331530}
+--- !u!1001 &1270896110
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 43, y: 22, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1240331532
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1240331530}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Loremark
---- !u!1 &1256598447
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1256598448}
-  - component: {fileID: 1256598449}
-  m_Layer: 0
-  m_Name: S17W-37
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1256598448
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 56.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: NevDolar
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: NevDolar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1270896111 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1270896110}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1256598447}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 70, y: 97, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1256598449
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1256598447}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-37
-  mapByteOffset: 12784
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1288277092
+--- !u!1 &1281269318
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6462,151 +8639,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1288277093}
-  - component: {fileID: 1288277094}
-  m_Layer: 0
-  m_Name: CryptofBaal
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1288277093
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288277092}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 82, y: 38, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1288277094
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1288277092}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: CryptofBaal
---- !u!1 &1290561147
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1290561148}
-  - component: {fileID: 1290561149}
-  m_Layer: 0
-  m_Name: S17W-19
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1290561148
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1290561147}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 38, y: 111, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1290561149
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1290561147}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-19
-  mapByteOffset: 9668
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1304985205
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1304985206}
-  - component: {fileID: 1304985207}
-  m_Layer: 0
-  m_Name: Zhoran
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1304985206
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1304985205}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 28, y: 93, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1304985207
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1304985205}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Zhoran
---- !u!1 &1306376686
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1306376687}
-  - component: {fileID: 1306376688}
+  - component: {fileID: 1281269319}
+  - component: {fileID: 1281269320}
   m_Layer: 0
   m_Name: S17W-52
   m_TagString: Untagged
@@ -6614,28 +8648,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1306376687
+--- !u!4 &1281269319
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1306376686}
+  m_GameObject: {fileID: 1281269318}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 84, y: 137, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1306376688
+--- !u!114 &1281269320
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1306376686}
+  m_GameObject: {fileID: 1281269318}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -6650,7 +8684,323 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1310152243
+--- !u!1001 &1293150454
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 69.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 23.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DawnStone
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DawnStone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1293150455 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1293150454}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1307153500
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gunthang
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 32
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 124
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gunthang
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1307153501 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1307153500}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1308561381
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 94.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: TombofNaar
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: TombofNaar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1308561382 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1308561381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1311301816
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Enmouth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 115
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Enmouth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1311301817 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1311301816}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1321070471
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6658,44 +9008,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1310152244}
-  - component: {fileID: 1310152245}
+  - component: {fileID: 1321070472}
+  - component: {fileID: 1321070473}
   m_Layer: 0
-  m_Name: S17W-18
+  m_Name: S17W-04
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1310152244
+--- !u!4 &1321070472
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1310152243}
+  m_GameObject: {fileID: 1321070471}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 37, y: 69, z: 0}
+  m_LocalPosition: {x: 12, y: 119, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1310152245
+--- !u!114 &1321070473
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1310152243}
+  m_GameObject: {fileID: 1321070471}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-18
-  mapByteOffset: 18822
+  siteAnchorId: S17W-04
+  mapByteOffset: 7872
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -6703,7 +9053,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1333623141
+--- !u!1 &1331182060
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6711,89 +9061,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1333623142}
-  - component: {fileID: 1333623143}
+  - component: {fileID: 1331182061}
+  - component: {fileID: 1331182062}
   m_Layer: 0
-  m_Name: HarvestStone
+  m_Name: S17W-60
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1333623142
+--- !u!4 &1331182061
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1333623141}
+  m_GameObject: {fileID: 1331182060}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 12, y: 101, z: 0}
+  m_LocalPosition: {x: 92, y: 77, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1333623143
+--- !u!114 &1331182062
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1333623141}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: HarvestStone
---- !u!1 &1339294172
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1339294173}
-  - component: {fileID: 1339294174}
-  m_Layer: 0
-  m_Name: S17W-34
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1339294173
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1339294172}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 65, y: 102, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1339294174
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1339294172}
+  m_GameObject: {fileID: 1331182060}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-34
-  mapByteOffset: 11684
+  siteAnchorId: S17W-60
+  mapByteOffset: 17188
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -6801,7 +9106,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1348053792
+--- !u!1 &1337929244
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6809,44 +9114,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1348053793}
-  - component: {fileID: 1348053794}
+  - component: {fileID: 1337929245}
+  - component: {fileID: 1337929246}
   m_Layer: 0
-  m_Name: S17W-12
+  m_Name: S17W-01
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1348053793
+--- !u!4 &1337929245
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1348053792}
+  m_GameObject: {fileID: 1337929244}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 22, y: 30, z: 0}
+  m_LocalPosition: {x: 4, y: 146, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1348053794
+--- !u!114 &1337929246
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1348053792}
+  m_GameObject: {fileID: 1337929244}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-12
-  mapByteOffset: 27294
+  siteAnchorId: S17W-01
+  mapByteOffset: 1970
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -6854,7 +9159,323 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1369184870
+--- !u!1001 &1350915012
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Jessarton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 96
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Jessarton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1350915013 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1350915012}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1356154758
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: AkFarzon
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 120
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: AkFarzon
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1356154759 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1356154758}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1371245908
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Stormheim
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 47
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Stormheim
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1371245909 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1371245908}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1376430227
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Himelton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 59
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Himelton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1376430228 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1376430227}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1405312979
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6862,89 +9483,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1369184871}
-  - component: {fileID: 1369184872}
+  - component: {fileID: 1405312980}
+  - component: {fileID: 1405312981}
   m_Layer: 0
-  m_Name: TempleofMiridine
+  m_Name: S17W-44
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1369184871
+--- !u!4 &1405312980
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1369184870}
+  m_GameObject: {fileID: 1405312979}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 74, y: 8, z: 0}
+  m_LocalPosition: {x: 73, y: 34, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1369184872
+--- !u!114 &1405312981
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1369184870}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TempleofMiridine
---- !u!1 &1370736035
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1370736036}
-  - component: {fileID: 1370736037}
-  m_Layer: 0
-  m_Name: S17W-32
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1370736036
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1370736035}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 60, y: 14, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1370736037
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1370736035}
+  m_GameObject: {fileID: 1405312979}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-32
-  mapByteOffset: 30858
+  siteAnchorId: S17W-44
+  mapByteOffset: 26524
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -6952,7 +9528,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1375387431
+--- !u!1001 &1413564458
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 89.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: WizardsHearth
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: WizardsHearth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1413564459 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1413564458}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1419864814
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -6960,44 +9615,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1375387432}
-  - component: {fileID: 1375387433}
+  - component: {fileID: 1419864815}
+  - component: {fileID: 1419864816}
   m_Layer: 0
-  m_Name: S17W-29
+  m_Name: S17W-16
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1375387432
+--- !u!4 &1419864815
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375387431}
+  m_GameObject: {fileID: 1419864814}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 56, y: 17, z: 0}
+  m_LocalPosition: {x: 27, y: 54, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1375387433
+--- !u!114 &1419864816
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1375387431}
+  m_GameObject: {fileID: 1419864814}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-29
-  mapByteOffset: 30196
+  siteAnchorId: S17W-16
+  mapByteOffset: 22072
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -7005,7 +9660,244 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1380952433
+--- !u!1001 &1427107417
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: BanesCitadel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 92
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 130
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: BanesCitadel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1427107418 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1427107417}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1440940003
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Charling
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Charling
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1440940004 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1440940003}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1445124151
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 74.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: GiantsTomb
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: GiantsTomb
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1445124152 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1445124151}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1447443199
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7013,359 +9905,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1380952434}
-  - component: {fileID: 1380952435}
+  - component: {fileID: 1447443200}
+  - component: {fileID: 1447443201}
   m_Layer: 0
-  m_Name: Amenal
+  m_Name: S17W-56
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1380952434
+--- !u!4 &1447443200
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1380952433}
+  m_GameObject: {fileID: 1447443199}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 12, y: 140, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1380952435
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1380952433}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Amenal
---- !u!1 &1381243201
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1381243202}
-  - component: {fileID: 1381243203}
-  m_Layer: 0
-  m_Name: Vernon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1381243202
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1381243201}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 48, y: 65, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1381243203
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1381243201}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Vernon
---- !u!1 &1385896680
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1385896681}
-  - component: {fileID: 1385896682}
-  m_Layer: 0
-  m_Name: Derridon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1385896681
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1385896680}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 54, y: 82, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1385896682
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1385896680}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Derridon
---- !u!1 &1389114153
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1389114154}
-  - component: {fileID: 1389114155}
-  m_Layer: 0
-  m_Name: DruidsTemple
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1389114154
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1389114153}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 49, y: 144, z: 0}
+  m_LocalPosition: {x: 91, y: 63, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1389114155
+--- !u!114 &1447443201
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1389114153}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: DruidsTemple
---- !u!1 &1400237181
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1400237182}
-  - component: {fileID: 1400237183}
-  m_Layer: 0
-  m_Name: Enmouth
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1400237182
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1400237181}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7, y: 115, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1400237183
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1400237181}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Enmouth
---- !u!1 &1426471403
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1426471404}
-  - component: {fileID: 1426471405}
-  m_Layer: 0
-  m_Name: Hithos
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1426471404
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1426471403}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 20, y: 70, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1426471405
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1426471403}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Hithos
---- !u!1 &1432206040
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1432206041}
-  - component: {fileID: 1432206042}
-  m_Layer: 0
-  m_Name: AkEnlie
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1432206041
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1432206040}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 20, y: 120, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1432206042
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1432206040}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: AkEnlie
---- !u!1 &1432629151
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1432629152}
-  - component: {fileID: 1432629153}
-  m_Layer: 0
-  m_Name: S17W-61
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1432629152
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1432629151}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 93, y: 56, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1432629153
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1432629151}
+  m_GameObject: {fileID: 1447443199}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-61
-  mapByteOffset: 21768
+  siteAnchorId: S17W-56
+  mapByteOffset: 20238
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -7373,7 +9950,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1484261410
+--- !u!1 &1457457846
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7381,134 +9958,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1484261411}
-  - component: {fileID: 1484261412}
+  - component: {fileID: 1457457847}
+  - component: {fileID: 1457457848}
   m_Layer: 0
-  m_Name: Zaigonne
+  m_Name: S17W-55
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1484261411
+--- !u!4 &1457457847
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1484261410}
+  m_GameObject: {fileID: 1457457846}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 83, y: 150, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1484261412
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1484261410}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Zaigonne
---- !u!1 &1485415818
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1485415819}
-  - component: {fileID: 1485415820}
-  m_Layer: 0
-  m_Name: Gluk
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1485415819
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1485415818}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 84, y: 25, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1485415820
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1485415818}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Gluk
---- !u!1 &1487680117
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1487680118}
-  - component: {fileID: 1487680119}
-  m_Layer: 0
-  m_Name: S17W-26
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1487680118
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1487680117}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 52, y: 54, z: 0}
+  m_LocalPosition: {x: 90, y: 43, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1487680119
+--- !u!114 &1457457848
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1487680117}
+  m_GameObject: {fileID: 1457457846}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-26
-  mapByteOffset: 22122
+  siteAnchorId: S17W-55
+  mapByteOffset: 24596
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -7516,7 +10003,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1487992547
+--- !u!1001 &1461372680
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Khorfe
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Khorfe
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1461372681 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1461372680}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1464920108
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7524,89 +10090,229 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1487992548}
-  - component: {fileID: 1487992549}
+  - component: {fileID: 1464920109}
+  - component: {fileID: 1464920110}
   m_Layer: 0
-  m_Name: Khorfe
+  m_Name: S17W-49
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1487992548
+--- !u!4 &1464920109
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1487992547}
+  m_GameObject: {fileID: 1464920108}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 8, y: 25, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1487992549
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1487992547}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Khorfe
---- !u!1 &1489550084
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1489550085}
-  - component: {fileID: 1489550086}
-  m_Layer: 0
-  m_Name: S17W-62
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1489550085
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1489550084}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 95, y: 139, z: 0}
+  m_LocalPosition: {x: 77, y: 114, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1489550086
+--- !u!114 &1464920110
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1489550084}
+  m_GameObject: {fileID: 1464920108}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-62
-  mapByteOffset: 3678
+  siteAnchorId: S17W-49
+  mapByteOffset: 9092
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1469436228
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Amenal
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 140
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Amenal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1469436229 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1469436228}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1488393896
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1488393897}
+  - component: {fileID: 1488393898}
+  m_Layer: 0
+  m_Name: S17W-47
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1488393897
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1488393896}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 77, y: 144, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1488393898
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1488393896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-47
+  mapByteOffset: 2552
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1491074897
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1491074898}
+  - component: {fileID: 1491074899}
+  m_Layer: 0
+  m_Name: S17W-57
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1491074898
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491074897}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 91, y: 56, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1491074899
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1491074897}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-57
+  mapByteOffset: 21764
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -7620,51 +10326,85 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 3274794878370800250}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1500113118
-GameObject:
+--- !u!1001 &1503230851
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1500113119}
-  - component: {fileID: 1500113120}
-  m_Layer: 0
-  m_Name: Duinoth
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1500113119
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1500113118}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 68, y: 49, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1500113120
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 100.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 46.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: Guardian
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: Guardian
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1503230852 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1503230851}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1500113118}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Duinoth
 --- !u!1 &1519475457
 GameObject:
   m_ObjectHideFlags: 0
@@ -7839,7 +10579,402 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1519475457}
   m_CullTransparentMesh: 1
---- !u!1 &1543818223
+--- !u!1001 &1523166801
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: DharKhosis
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 74
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: DharKhosis
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1523166802 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1523166801}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1541066204
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 49.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 144.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DruidsTemple
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DruidsTemple
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1541066205 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1541066204}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1546381380
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Upbourne
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Upbourne
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1546381381 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1546381380}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1552600067
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Loremark
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Loremark
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1552600068 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1552600067}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1553444546
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: CitadelofFire
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 59
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 73
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: CitadelofFire
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1553444547 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1553444546}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1577780677
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7847,89 +10982,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1543818224}
-  - component: {fileID: 1543818225}
+  - component: {fileID: 1577780678}
+  - component: {fileID: 1577780679}
   m_Layer: 0
-  m_Name: RuinsofKabor
+  m_Name: S17W-11
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1543818224
+--- !u!4 &1577780678
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1543818223}
+  m_GameObject: {fileID: 1577780677}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 44, y: 98, z: 0}
+  m_LocalPosition: {x: 20, y: 17, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1543818225
+--- !u!114 &1577780679
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1543818223}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: RuinsofKabor
---- !u!1 &1554759104
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1554759105}
-  - component: {fileID: 1554759106}
-  m_Layer: 0
-  m_Name: S17W-25
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1554759105
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1554759104}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 52, y: 112, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1554759106
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1554759104}
+  m_GameObject: {fileID: 1577780677}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-25
-  mapByteOffset: 9478
+  siteAnchorId: S17W-11
+  mapByteOffset: 30124
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -7937,7 +11027,244 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1555886812
+--- !u!1001 &1598342654
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 66.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 53.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: Gemhold
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: Gemhold
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1598342655 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1598342654}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1605303583
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gluk
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 84
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 25
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gluk
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1605303584 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1605303583}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1620176427
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 29.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: ThroneofBalnor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: ThroneofBalnor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1620176428 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1620176427}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1638157247
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7945,89 +11272,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1555886813}
-  - component: {fileID: 1555886814}
+  - component: {fileID: 1638157248}
+  - component: {fileID: 1638157249}
   m_Layer: 0
-  m_Name: BanesCitadel
+  m_Name: S17W-15
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1555886813
+--- !u!4 &1638157248
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1555886812}
+  m_GameObject: {fileID: 1638157247}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 92, y: 130, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1555886814
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1555886812}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: BanesCitadel
---- !u!1 &1578618459
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1578618460}
-  - component: {fileID: 1578618461}
-  m_Layer: 0
-  m_Name: S17W-01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1578618460
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1578618459}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4, y: 146, z: 0}
+  m_LocalPosition: {x: 23, y: 116, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1578618461
+--- !u!114 &1638157249
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1578618459}
+  m_GameObject: {fileID: 1638157247}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-01
-  mapByteOffset: 1970
+  siteAnchorId: S17W-15
+  mapByteOffset: 8548
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -8035,7 +11317,86 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1583966526
+--- !u!1001 &1641722177
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Herzag
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 78
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 67
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Herzag
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1641722178 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1641722177}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1660598209
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8043,269 +11404,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1583966527}
-  - component: {fileID: 1583966528}
+  - component: {fileID: 1660598210}
+  - component: {fileID: 1660598211}
   m_Layer: 0
-  m_Name: Waybourne
+  m_Name: S17W-51
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1583966527
+--- !u!4 &1660598210
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1583966526}
+  m_GameObject: {fileID: 1660598209}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4, y: 103, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1583966528
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1583966526}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Waybourne
---- !u!1 &1585880401
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1585880402}
-  - component: {fileID: 1585880403}
-  m_Layer: 0
-  m_Name: TheOldInn
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1585880402
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1585880401}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 24, y: 33, z: 0}
+  m_LocalPosition: {x: 81, y: 59, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1585880403
+--- !u!114 &1660598211
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1585880401}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TheOldInn
---- !u!1 &1615586697
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1615586698}
-  - component: {fileID: 1615586699}
-  m_Layer: 0
-  m_Name: Argrond
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1615586698
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615586697}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 88, y: 115, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1615586699
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615586697}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Argrond
---- !u!1 &1635037803
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1635037804}
-  - component: {fileID: 1635037805}
-  m_Layer: 0
-  m_Name: Elvallie
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1635037804
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1635037803}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 41, y: 30, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1635037805
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1635037803}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Elvallie
---- !u!1 &1642929335
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1642929336}
-  - component: {fileID: 1642929337}
-  m_Layer: 0
-  m_Name: DragontowerRuins
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1642929336
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1642929335}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 93, y: 87, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1642929337
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1642929335}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: DragontowerRuins
---- !u!1 &1644485417
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1644485418}
-  - component: {fileID: 1644485419}
-  m_Layer: 0
-  m_Name: S17W-59
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1644485418
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1644485417}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 92, y: 125, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1644485419
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1644485417}
+  m_GameObject: {fileID: 1660598209}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-59
-  mapByteOffset: 6724
+  siteAnchorId: S17W-51
+  mapByteOffset: 21090
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -8313,7 +11449,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1647803127
+--- !u!1 &1727064487
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8321,269 +11457,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1647803128}
-  - component: {fileID: 1647803129}
+  - component: {fileID: 1727064488}
+  - component: {fileID: 1727064489}
   m_Layer: 0
-  m_Name: DarkBarrows
+  m_Name: S17W-34
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1647803128
+--- !u!4 &1727064488
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647803127}
+  m_GameObject: {fileID: 1727064487}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57, y: 74, z: 0}
+  m_LocalPosition: {x: 65, y: 102, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1647803129
+--- !u!114 &1727064489
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1647803127}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: DarkBarrows
---- !u!1 &1648774069
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1648774070}
-  - component: {fileID: 1648774071}
-  m_Layer: 0
-  m_Name: Gimlad
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1648774070
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1648774069}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 89, y: 67, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1648774071
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1648774069}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Gimlad
---- !u!1 &1654481004
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1654481005}
-  - component: {fileID: 1654481006}
-  m_Layer: 0
-  m_Name: DwarfHalls
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1654481005
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1654481004}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 34, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1654481006
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1654481004}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: DwarfHalls
---- !u!1 &1668124582
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1668124583}
-  - component: {fileID: 1668124584}
-  m_Layer: 0
-  m_Name: Dunethel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1668124583
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1668124582}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 60, y: 83, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1668124584
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1668124582}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Dunethel
---- !u!1 &1672326515
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1672326516}
-  - component: {fileID: 1672326517}
-  m_Layer: 0
-  m_Name: MirksDecay
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1672326516
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1672326515}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 69, y: 137, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1672326517
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1672326515}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: MirksDecay
---- !u!1 &1679469665
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1679469666}
-  - component: {fileID: 1679469667}
-  m_Layer: 0
-  m_Name: S17W-14
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1679469666
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1679469665}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 23, y: 128, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1679469667
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1679469665}
+  m_GameObject: {fileID: 1727064487}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-14
-  mapByteOffset: 5932
+  siteAnchorId: S17W-34
+  mapByteOffset: 11684
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -8591,7 +11502,323 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1687503149
+--- !u!1001 &1751642075
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Upway
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 46
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 101
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Upway
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1751642076 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1751642075}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1773672587
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Wellmore
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 51
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Wellmore
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1773672588 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1773672587}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1779931296
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 44.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 98.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: RuinsofKabor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: RuinsofKabor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1779931297 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1779931296}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1783643537
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 105.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: TempleofLurinth
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: TempleofLurinth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &1783643538 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 1783643537}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1792841182
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8599,44 +11826,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1687503150}
-  - component: {fileID: 1687503151}
+  - component: {fileID: 1792841183}
+  - component: {fileID: 1792841184}
   m_Layer: 0
-  m_Name: S17W-05
+  m_Name: S17W-10
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1687503150
+--- !u!4 &1792841183
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687503149}
+  m_GameObject: {fileID: 1792841182}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 14, y: 31, z: 0}
+  m_LocalPosition: {x: 19, y: 117, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1687503151
+--- !u!114 &1792841184
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1687503149}
+  m_GameObject: {fileID: 1792841182}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-05
-  mapByteOffset: 27060
+  siteAnchorId: S17W-10
+  mapByteOffset: 8322
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -8644,97 +11871,171 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1744529938
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+--- !u!224 &1804101478 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7479798158668484229, guid: f6b373a3c5d10614dbef98eb81cfab37,
+    type: 3}
+  m_PrefabInstance: {fileID: 7479798159028660707}
   m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1744529939}
-  - component: {fileID: 1744529940}
-  m_Layer: 0
-  m_Name: NirnsCrypt
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1744529939
-Transform:
+--- !u!1001 &1814254250
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1744529938}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 45, y: 84, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1744529940
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1744529938}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: NirnsCrypt
---- !u!1 &1757483316
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1757483317}
-  - component: {fileID: 1757483318}
-  m_Layer: 0
-  m_Name: Fleymark
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1757483317
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Hithos
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 70
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Hithos
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1814254251 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1814254250}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1757483316}
+--- !u!1001 &1823262578
+PrefabInstance:
+  m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 68, y: 81, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1757483318
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 77.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DwarfHalls
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DwarfHalls
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1823262579 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1823262578}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1757483316}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Fleymark
---- !u!1 &1772214043
+--- !u!1 &1829056165
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8742,8 +12043,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1772214044}
-  - component: {fileID: 1772214045}
+  - component: {fileID: 1829056166}
+  - component: {fileID: 1829056167}
   m_Layer: 0
   m_Name: S17W-09
   m_TagString: Untagged
@@ -8751,28 +12052,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1772214044
+--- !u!4 &1829056166
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1772214043}
+  m_GameObject: {fileID: 1829056165}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 18, y: 113, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1772214045
+--- !u!114 &1829056167
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1772214043}
+  m_GameObject: {fileID: 1829056165}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -8787,7 +12088,165 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1787075039
+--- !u!1001 &1837246514
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gork
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 86
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gork
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1837246515 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1837246514}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1837989428
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Ssuri
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 59
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Ssuri
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1837989429 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1837989428}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1839947479
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8795,8 +12254,936 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1787075040}
-  - component: {fileID: 1787075041}
+  - component: {fileID: 1839947480}
+  - component: {fileID: 1839947481}
+  m_Layer: 0
+  m_Name: S17W-30
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1839947480
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839947479}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 57, y: 29, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1839947481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1839947479}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-30
+  mapByteOffset: 27582
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1845674350
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 155.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: Monolyth
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: Monolyth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1845674351 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1845674350}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1860121019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1860121021}
+  - component: {fileID: 1860121020}
+  m_Layer: 0
+  m_Name: Locations
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1860121020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1860121019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a860770c2175fa4db0bef3e7b3b5a2f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationContainer
+  ImportLocationsFromTilemap: 0
+  Reset: 0
+  LibraryPrefab: {fileID: 0}
+  RuinsPrefab: {fileID: 0}
+  SagePrefab: {fileID: 0}
+  TemplePrefab: {fileID: 0}
+  TombPrefab: {fileID: 0}
+  TotalLocations: 0
+--- !u!4 &1860121021
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1860121019}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 425138700}
+  - {fileID: 953755986}
+  - {fileID: 333493214}
+  - {fileID: 2025305584}
+  - {fileID: 737233883}
+  - {fileID: 29706987}
+  - {fileID: 1783643538}
+  - {fileID: 1965348406}
+  - {fileID: 463877896}
+  - {fileID: 371174454}
+  - {fileID: 1083960863}
+  - {fileID: 941280969}
+  - {fileID: 1541066205}
+  - {fileID: 1779931297}
+  - {fileID: 885622284}
+  - {fileID: 804887381}
+  - {fileID: 1993925771}
+  - {fileID: 1413564459}
+  - {fileID: 645376916}
+  - {fileID: 2050259357}
+  - {fileID: 865215782}
+  - {fileID: 651858885}
+  - {fileID: 609163788}
+  - {fileID: 1270896111}
+  - {fileID: 199481286}
+  - {fileID: 700803661}
+  - {fileID: 1620176428}
+  - {fileID: 1445124152}
+  - {fileID: 77911054}
+  - {fileID: 2109113713}
+  - {fileID: 1200497010}
+  - {fileID: 1293150455}
+  - {fileID: 1598342655}
+  - {fileID: 955276895}
+  - {fileID: 1823262579}
+  - {fileID: 1503230852}
+  - {fileID: 568907618}
+  - {fileID: 1026372774}
+  - {fileID: 1308561382}
+  - {fileID: 1845674351}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1868516698 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7972507524430896441, guid: eef716d4c750af84b9ab4224489408c5,
+    type: 3}
+  m_PrefabInstance: {fileID: 7972507522999930979}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1868516699 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7972507524430896440, guid: eef716d4c750af84b9ab4224489408c5,
+    type: 3}
+  m_PrefabInstance: {fileID: 7972507522999930979}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1874487366
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1874487367}
+  - component: {fileID: 1874487368}
+  m_Layer: 0
+  m_Name: S17W-41
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1874487367
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1874487366}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 72, y: 56, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1874487368
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1874487366}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-41
+  mapByteOffset: 21726
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1875173422
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1875173423}
+  - component: {fileID: 1875173424}
+  m_Layer: 0
+  m_Name: S17W-48
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1875173423
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875173422}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 77, y: 142, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1875173424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1875173422}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-48
+  mapByteOffset: 2988
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1878608645
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Paynor
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 83
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 89
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Paynor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1878608646 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1878608645}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1879778974
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Needleton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 56
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 127
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Needleton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1879778975 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1879778974}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1880705472
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Maridun
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 57
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 97
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Maridun
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1880705473 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1880705472}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1892315348
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Thurtz
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Thurtz
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1892315349 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1892315348}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1916110662
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1916110663}
+  - component: {fileID: 1916110664}
+  m_Layer: 0
+  m_Name: S17W-22
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1916110663
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1916110662}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 49, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1916110664
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1916110662}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-22
+  mapByteOffset: 9472
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1923041881
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1923041882}
+  - component: {fileID: 1923041883}
+  m_Layer: 0
+  m_Name: S17W-06
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1923041882
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1923041881}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 15, y: 72, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 818195351}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1923041883
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1923041881}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-06
+  mapByteOffset: 18124
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!224 &1946148656 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8642409218828357444, guid: ea2e4ebd299bfb1468a788172bf2b729,
+    type: 3}
+  m_PrefabInstance: {fileID: 8642409219572404340}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1954145111
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: AlfarsGap
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 22
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: AlfarsGap
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1954145112 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1954145111}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1965348405
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 131.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: GrandOracle
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: GrandOracle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &1965348406 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 1965348405}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1969623973
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1969623974}
+  - component: {fileID: 1969623975}
   m_Layer: 0
   m_Name: S17W-17
   m_TagString: Untagged
@@ -8804,28 +13191,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1787075040
+--- !u!4 &1969623974
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787075039}
+  m_GameObject: {fileID: 1969623973}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 35, y: 69, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1787075041
+--- !u!114 &1969623975
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1787075039}
+  m_GameObject: {fileID: 1969623973}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -8840,1008 +13227,402 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!224 &1804101478 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7479798158668484229, guid: f6b373a3c5d10614dbef98eb81cfab37,
+--- !u!1001 &1993925770
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 69.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 137.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: MirksDecay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: MirksDecay
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1993925771 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 7479798159028660707}
+  m_PrefabInstance: {fileID: 1993925770}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1807414437
-GameObject:
+--- !u!1001 &2013534729
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1807414438}
-  - component: {fileID: 1807414439}
-  m_Layer: 0
-  m_Name: Darclan
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1807414438
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1807414437}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91, y: 99, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1807414439
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1807414437}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Darclan
---- !u!1 &1811749616
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1811749617}
-  - component: {fileID: 1811749618}
-  m_Layer: 0
-  m_Name: Maridun
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1811749617
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Pareth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 57
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 138
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Pareth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2013534730 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1811749616}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57, y: 97, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1811749618
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1811749616}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Maridun
---- !u!1 &1842900926
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1842900927}
-  - component: {fileID: 1842900928}
-  m_Layer: 0
-  m_Name: Beleri
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1842900927
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1842900926}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 15, y: 149, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1842900928
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1842900926}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Beleri
---- !u!1 &1844045150
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1844045151}
-  - component: {fileID: 1844045152}
-  m_Layer: 0
-  m_Name: DharKhosis
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1844045151
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1844045150}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 37, y: 74, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1844045152
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1844045150}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: DharKhosis
---- !u!1 &1845318795
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1845318796}
-  - component: {fileID: 1845318797}
-  m_Layer: 0
-  m_Name: Khamar
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1845318796
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1845318795}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 39, y: 92, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1845318797
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1845318795}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Khamar
---- !u!1 &1845695329
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1845695330}
-  - component: {fileID: 1845695331}
-  m_Layer: 0
-  m_Name: AkFarzon
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1845695330
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1845695329}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 33, y: 120, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1845695331
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1845695329}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: AkFarzon
---- !u!1 &1867166144
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1867166145}
-  - component: {fileID: 1867166146}
-  m_Layer: 0
-  m_Name: S17W-07
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1867166145
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1867166144}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 15, y: 28, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1867166146
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1867166144}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-07
-  mapByteOffset: 27716
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1867916650
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1867916651}
-  - component: {fileID: 1867916652}
-  m_Layer: 0
-  m_Name: Paynor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1867916651
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1867916650}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 83, y: 89, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1867916652
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1867916650}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Paynor
---- !u!1 &1868516698 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7972507524430896441, guid: eef716d4c750af84b9ab4224489408c5,
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 7972507522999930979}
+  m_PrefabInstance: {fileID: 2013534729}
   m_PrefabAsset: {fileID: 0}
---- !u!224 &1868516699 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7972507524430896440, guid: eef716d4c750af84b9ab4224489408c5,
+--- !u!1001 &2025305583
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 38.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: GoldenLibrary
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: GoldenLibrary
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &2025305584 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
     type: 3}
-  m_PrefabInstance: {fileID: 7972507522999930979}
+  m_PrefabInstance: {fileID: 2025305583}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1881936020
-GameObject:
+--- !u!1001 &2046591603
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1881936021}
-  - component: {fileID: 1881936022}
-  m_Layer: 0
-  m_Name: Ungor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1881936021
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1881936020}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 87, y: 136, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1881936022
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1881936020}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Ungor
---- !u!1 &1882091839
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1882091840}
-  - component: {fileID: 1882091841}
-  m_Layer: 0
-  m_Name: Galin
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1882091840
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Argrond
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 88
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 115
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Argrond
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2046591604 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882091839}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 41, y: 67, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1882091841
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1882091839}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Galin
---- !u!1 &1891619821
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1891619822}
-  - component: {fileID: 1891619823}
-  m_Layer: 0
-  m_Name: S17W-23
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1891619822
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1891619821}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 50, y: 19, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1891619823
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1891619821}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-23
-  mapByteOffset: 29748
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1898256568
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1898256569}
-  - component: {fileID: 1898256570}
-  m_Layer: 0
-  m_Name: Pareth
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1898256569
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1898256568}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57, y: 138, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1898256570
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1898256568}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Pareth
---- !u!1 &1898582764
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1898582765}
-  - component: {fileID: 1898582766}
-  m_Layer: 0
-  m_Name: Gunthang
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1898582765
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1898582764}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 32, y: 124, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1898582766
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1898582764}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Gunthang
---- !u!1 &1900865272
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1900865273}
-  - component: {fileID: 1900865274}
-  m_Layer: 0
-  m_Name: ArArak
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1900865273
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1900865272}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 95, y: 75, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1900865274
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1900865272}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: ArArak
---- !u!1 &1910667174
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1910667175}
-  - component: {fileID: 1910667176}
-  m_Layer: 0
-  m_Name: DawnStone
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1910667175
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1910667174}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 69, y: 23, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1910667176
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1910667174}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: DawnStone
---- !u!1 &1932770634
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1932770635}
-  - component: {fileID: 1932770636}
-  m_Layer: 0
-  m_Name: S17W-04
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1932770635
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1932770634}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 12, y: 119, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1932770636
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1932770634}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-04
-  mapByteOffset: 7872
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1934986031
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1934986032}
-  - component: {fileID: 1934986033}
-  m_Layer: 0
-  m_Name: ThroneofBalnor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1934986032
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1934986031}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 24, y: 29, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1934986033
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1934986031}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: ThroneofBalnor
---- !u!1 &1936336608
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1936336609}
-  - component: {fileID: 1936336610}
-  m_Layer: 0
-  m_Name: OldWoodsTower
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1936336609
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1936336608}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 29, y: 131, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1936336610
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1936336608}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: OldWoodsTower
---- !u!1 &1938284325
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1938284326}
-  - component: {fileID: 1938284327}
-  m_Layer: 0
-  m_Name: Herueth
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1938284326
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1938284325}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 65, y: 32, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1938284327
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1938284325}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Herueth
---- !u!224 &1946148656 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8642409218828357444, guid: ea2e4ebd299bfb1468a788172bf2b729,
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 8642409219572404340}
+  m_PrefabInstance: {fileID: 2046591603}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1946767548
-GameObject:
+--- !u!1001 &2050259356
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1946767549}
-  - component: {fileID: 1946767550}
-  m_Layer: 0
-  m_Name: S17W-44
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1946767549
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1946767548}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 73, y: 34, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1946767550
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1946767548}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-44
-  mapByteOffset: 26524
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1949247051
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1949247052}
-  - component: {fileID: 1949247053}
-  m_Layer: 0
-  m_Name: Gorag
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1949247052
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 92.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 149.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: Bridgetower
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: Bridgetower
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &2050259357 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2050259356}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1949247051}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 94, y: 136, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1949247053
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1949247051}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Gorag
---- !u!1 &1950118308
+--- !u!1 &2051036622
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -9849,8 +13630,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1950118309}
-  - component: {fileID: 1950118310}
+  - component: {fileID: 2051036623}
+  - component: {fileID: 2051036624}
   m_Layer: 0
   m_Name: S17W-08
   m_TagString: Untagged
@@ -9858,28 +13639,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1950118309
+--- !u!4 &2051036623
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1950118308}
+  m_GameObject: {fileID: 2051036622}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 18, y: 125, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1950118310
+--- !u!114 &2051036624
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1950118308}
+  m_GameObject: {fileID: 2051036622}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -9894,284 +13675,6 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1974692415
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1974692416}
-  - component: {fileID: 1974692417}
-  m_Layer: 0
-  m_Name: S17W-56
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1974692416
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1974692415}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91, y: 63, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1974692417
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1974692415}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-56
-  mapByteOffset: 20238
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1979117229
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1979117230}
-  - component: {fileID: 1979117231}
-  m_Layer: 0
-  m_Name: Ubar
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1979117230
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1979117229}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 48, y: 69, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1979117231
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1979117229}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Ubar
---- !u!1 &1995627665
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1995627666}
-  - component: {fileID: 1995627667}
-  m_Layer: 0
-  m_Name: Jessarton
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1995627666
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995627665}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 6, y: 96, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1995627667
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1995627665}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Jessarton
---- !u!1 &2020993014
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2020993015}
-  - component: {fileID: 2020993016}
-  m_Layer: 0
-  m_Name: DuskStone
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2020993015
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2020993014}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 37, y: 10, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2020993016
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2020993014}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: DuskStone
---- !u!1 &2030235216
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2030235217}
-  - component: {fileID: 2030235218}
-  m_Layer: 0
-  m_Name: Tal
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2030235217
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2030235216}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 51, y: 148, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2030235218
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2030235216}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Tal
---- !u!1 &2035740379
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2035740380}
-  - component: {fileID: 2035740381}
-  m_Layer: 0
-  m_Name: Ohmsmouth
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2035740380
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2035740379}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7, y: 60, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2035740381
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2035740379}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Ohmsmouth
 --- !u!1 &2053934878
 GameObject:
   m_ObjectHideFlags: 0
@@ -10886,7 +14389,244 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1913c3afdd517ee49805ac6175fa2a08, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &2063296262
+--- !u!1001 &2060731879
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Herueth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 32
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Herueth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2060731880 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2060731879}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2065589676
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Derridon
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 54
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 82
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Derridon
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2065589677 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2065589676}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2067220330
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gorag
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 94
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 136
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gorag
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2067220331 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2067220330}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2086883950
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10894,134 +14634,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2063296263}
-  - component: {fileID: 2063296264}
+  - component: {fileID: 2086883951}
+  - component: {fileID: 2086883952}
   m_Layer: 0
-  m_Name: CryptofMolok
+  m_Name: S17W-07
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2063296263
+--- !u!4 &2086883951
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2063296262}
+  m_GameObject: {fileID: 2086883950}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 100, y: 93, z: 0}
+  m_LocalPosition: {x: 15, y: 28, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 815853887}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2063296264
+--- !u!114 &2086883952
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2063296262}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: CryptofMolok
---- !u!1 &2077732290
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2077732291}
-  - component: {fileID: 2077732292}
-  m_Layer: 0
-  m_Name: TowerofNight
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2077732291
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2077732290}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 87, y: 30, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 815853887}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2077732292
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2077732290}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7787bb1e7bcd5db4bbbf52c1ab2d3019, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationEntry
-  locationShortName: TowerofNight
---- !u!1 &2094547021
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2094547022}
-  - component: {fileID: 2094547023}
-  m_Layer: 0
-  m_Name: S17W-39
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2094547022
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2094547021}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 114, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 802442925}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2094547023
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2094547021}
+  m_GameObject: {fileID: 2086883950}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-39
-  mapByteOffset: 9082
+  siteAnchorId: S17W-07
+  mapByteOffset: 27716
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -11029,7 +14679,481 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &2102389402
+--- !u!1001 &2087984151
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Argenthorn
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Argenthorn
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2087984152 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2087984151}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2094990717
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Vernon
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 48
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Vernon
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2094990718 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2094990717}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2109113712
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 1860121021}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: RuinsofHaviel
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: RuinsofHaviel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &2109113713 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2109113712}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2116387896
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Angbar
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 54
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 45
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Angbar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2116387897 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2116387896}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2119169034
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Zaigonne
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 83
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Zaigonne
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2119169035 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2119169034}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2124823449
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Lador
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 31
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 49
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Lador
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2124823450 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2124823449}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2132718335
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -11037,134 +15161,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2102389403}
-  - component: {fileID: 2102389404}
+  - component: {fileID: 2132718336}
+  - component: {fileID: 2132718337}
   m_Layer: 0
-  m_Name: Himelton
+  m_Name: S17W-23
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2102389403
+--- !u!4 &2132718336
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2102389402}
+  m_GameObject: {fileID: 2132718335}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 22, y: 59, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2102389404
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2102389402}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Himelton
---- !u!1 &2116115536
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2116115537}
-  - component: {fileID: 2116115538}
-  m_Layer: 0
-  m_Name: Charling
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2116115537
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116115536}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 48, y: 33, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1000689320}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2116115538
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2116115536}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 077dcddda263fca468157908cc9cdb6f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.CityEntry
-  cityShortName: Charling
---- !u!1 &2139704566
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2139704567}
-  - component: {fileID: 2139704568}
-  m_Layer: 0
-  m_Name: S17W-58
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2139704567
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2139704566}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91, y: 45, z: 0}
+  m_LocalPosition: {x: 50, y: 19, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 802442925}
+  m_Father: {fileID: 818195351}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2139704568
+--- !u!114 &2132718337
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2139704566}
+  m_GameObject: {fileID: 2132718335}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-58
-  mapByteOffset: 24162
+  siteAnchorId: S17W-23
+  mapByteOffset: 29748
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -11172,6 +15206,85 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
+--- !u!1001 &2142612330
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 522548138}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Troy
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 56
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Troy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2142612331 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2142612330}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &147419114341941526
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -434253,7 +438366,9 @@ PrefabInstance:
       value: 65535
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
+    m_RemovedGameObjects:
+    - {fileID: 3274794877087100613, guid: d6d52c5e10715ff4aa2380c9e0e73b81, type: 3}
+    - {fileID: 3274794877701824585, guid: d6d52c5e10715ff4aa2380c9e0e73b81, type: 3}
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d6d52c5e10715ff4aa2380c9e0e73b81, type: 3}
@@ -435459,6 +439574,6 @@ SceneRoots:
   - {fileID: 222812357}
   - {fileID: 149804624}
   - {fileID: 93653620}
-  - {fileID: 1000689320}
-  - {fileID: 815853887}
-  - {fileID: 802442925}
+  - {fileID: 522548138}
+  - {fileID: 1860121021}
+  - {fileID: 818195351}

--- a/WismUnity/Assets/Scripts/UnityGame/Playground/Editor/WorldKitSceneBuilder.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Playground/Editor/WorldKitSceneBuilder.cs
@@ -18,6 +18,12 @@ namespace WismUnity.Playground
     {
         const string SourceScenePath = "Assets/Scenes/Mini-Illuria.unity";
         const string PluginWorldsRoot = "Assets/Plugins/WismClient/Mods/Worlds";
+        const string CityMarkerPrefabPath = "Assets/Prefab/Editor/City.prefab";
+        const string LibraryMarkerPrefabPath = "Assets/Prefab/Editor/Library.prefab";
+        const string RuinsMarkerPrefabPath = "Assets/Prefab/Editor/Ruins.prefab";
+        const string SageMarkerPrefabPath = "Assets/Prefab/Editor/Sage.prefab";
+        const string TempleMarkerPrefabPath = "Assets/Prefab/Editor/Temple.prefab";
+        const string TombMarkerPrefabPath = "Assets/Prefab/Editor/Tomb.prefab";
 
         [MenuItem("WISM/World Kit/Build Near-Illuria Scene")]
         public static void BuildNearIlluriaScene()
@@ -241,11 +247,19 @@ namespace WismUnity.Playground
                 AddSceneCheck(sceneCityNames.SetEquals(expectedCityNames), checks, issues, "Scene city marker names match MOD data.", "Scene city marker names do not match MOD data.");
                 AddSceneCheck(sceneLocationNames.SetEquals(expectedLocationNames), checks, issues, "Scene location marker names match MOD data.", "Scene location marker names do not match MOD data.");
                 AddSceneCheck(sceneSiteAnchorIds.SetEquals(expectedSiteAnchorIds), checks, issues, "Scene site anchor marker ids match MOD data.", "Scene site anchor marker ids do not match MOD data.");
+                AddSceneCheck(FindSceneGameObjects(scene, "Cities").Count == 1, checks, issues, "Scene has one Cities container.", $"Scene has {FindSceneGameObjects(scene, "Cities").Count} Cities containers.");
+                AddSceneCheck(FindSceneGameObjects(scene, "Locations").Count == 1, checks, issues, "Scene has one Locations container.", $"Scene has {FindSceneGameObjects(scene, "Locations").Count} Locations containers.");
+                AddSceneCheck(cityContainer.GetComponent<CityContainer>() != null, checks, issues, "Cities container has CityContainer settings.", "Cities container is missing CityContainer settings.");
+                AddSceneCheck(locationContainer.GetComponent<LocationContainer>() != null, checks, issues, "Locations container has LocationContainer settings.", "Locations container is missing LocationContainer settings.");
+                AddSceneCheck(CityMarkersAreRuntimeReady(cityEntries), checks, issues, "City markers have City tag, CityEntry, and SpriteRenderer.", "One or more city markers are missing City tag, CityEntry, or SpriteRenderer.");
+                AddSceneCheck(LocationMarkersAreRuntimeReady(locationEntries), checks, issues, "Location markers have Location tag, LocationEntry, and SpriteRenderer.", "One or more location markers are missing Location tag, LocationEntry, or SpriteRenderer.");
                 AddSceneCheck(grid == null || IsZeroTransform(grid.transform), checks, issues, "Generated Grid transform is normalized.", "Generated Grid transform is not normalized; copied scene offset is still present.");
                 AddSceneCheck(IsZeroLocalTransform(tilemap.transform), checks, issues, "Generated WorldTilemap local transform is normalized.", "Generated WorldTilemap local transform is not normalized.");
                 AddSceneCheck(CityMarkerPositionsMatch(cityEntries, cities, mapHeight), checks, issues, "Scene city marker positions match flipped MOD coordinates.", "Scene city marker positions do not match flipped MOD coordinates.");
                 AddSceneCheck(LocationMarkerPositionsMatch(locationEntries, locations, mapHeight), checks, issues, "Scene location marker positions match flipped MOD coordinates.", "Scene location marker positions do not match flipped MOD coordinates.");
                 AddSceneCheck(SiteAnchorPositionsMatch(siteAnchorEntries, siteAnchors, mapHeight), checks, issues, "Scene site anchor marker positions match flipped MOD coordinates.", "Scene site anchor marker positions do not match flipped MOD coordinates.");
+                AddSceneCheck(CityFootprintsArePainted(tilemap, cities, mapHeight), checks, issues, "City markers line up with painted 2x2 city footprints.", "One or more city markers do not line up with painted 2x2 city footprints.");
+                AddSceneCheck(LocationTilesArePainted(tilemap, locations, mapHeight), checks, issues, "Location markers line up with painted location tiles.", "One or more location markers do not line up with painted location tiles.");
 
                 return new JObject
                 {
@@ -446,9 +460,10 @@ namespace WismUnity.Playground
 
         static void RebuildCityObjects(Scene scene, Tilemap tilemap, IReadOnlyList<JObject> cities, int mapHeight)
         {
-            var container = FindOrCreateRoot(scene, "Cities");
+            var container = EnsureSceneContainer<CityContainer>(scene, "Cities");
             ClearChildren(container);
             var tileAssets = LoadTileAssets();
+            var markerPrefab = GetCityMarkerPrefab(container);
 
             foreach (var city in cities)
             {
@@ -462,20 +477,20 @@ namespace WismUnity.Playground
                 tilemap.SetTile(new Vector3Int(x + 1, y, 0), cityTile);
                 tilemap.SetTile(new Vector3Int(x + 1, y - 1, 0), cityTile);
 
-                var go = new GameObject(shortName);
-                go.transform.SetParent(container.transform, false);
-                go.transform.position = new Vector3(x, y - 1, 0);
+                var go = InstantiateMarker(markerPrefab, scene, container.transform, shortName);
+                go.tag = "City";
+                go.transform.position = tilemap.CellToWorld(new Vector3Int(x, y - 1, 0));
                 go.transform.localScale = new Vector3(2f, 2f, 1f);
-                go.AddComponent<CityEntry>().cityShortName = shortName;
+                EnsureComponent<CityEntry>(go).cityShortName = shortName;
+                EnsureComponent<SpriteRenderer>(go);
             }
         }
 
         static void RebuildLocationObjects(Scene scene, Tilemap tilemap, IReadOnlyList<JObject> locations, int mapHeight)
         {
-            var container = FindOrCreateRoot(scene, "Locations");
+            var container = EnsureSceneContainer<LocationContainer>(scene, "Locations");
             ClearChildren(container);
             var tileAssets = LoadTileAssets();
-
             foreach (var location in locations)
             {
                 var x = location.Value<int>("X");
@@ -487,11 +502,12 @@ namespace WismUnity.Playground
                     tilemap.SetTile(new Vector3Int(x, y, 0), tileAsset);
                 }
 
-                var go = new GameObject(shortName);
-                go.transform.SetParent(container.transform, false);
-                go.transform.position = new Vector3(x, y, 0);
+                var go = InstantiateMarker(GetLocationMarkerPrefab(terrain), scene, container.transform, shortName);
+                go.tag = "Location";
+                go.transform.position = GetCellCenter(tilemap, new Vector3Int(x, y, 0));
                 go.transform.localScale = Vector3.one;
-                go.AddComponent<LocationEntry>().locationShortName = shortName;
+                EnsureComponent<LocationEntry>(go).locationShortName = shortName;
+                EnsureComponent<SpriteRenderer>(go);
             }
         }
 
@@ -527,7 +543,7 @@ namespace WismUnity.Playground
                 .Where(city => !string.IsNullOrWhiteSpace(city.Value<string>("ShortName")))
                 .ToDictionary(
                     city => city.Value<string>("ShortName"),
-                    city => new Vector2Int(city.Value<int>("X"), ToUnityY(city.Value<int>("Y"), mapHeight) - 1),
+                    city => new Vector2(city.Value<int>("X"), ToUnityY(city.Value<int>("Y"), mapHeight) - 1),
                     StringComparer.OrdinalIgnoreCase);
 
             return entries.All(entry =>
@@ -541,7 +557,7 @@ namespace WismUnity.Playground
                 .Where(location => !string.IsNullOrWhiteSpace(location.Value<string>("ShortName")))
                 .ToDictionary(
                     location => location.Value<string>("ShortName"),
-                    location => new Vector2Int(location.Value<int>("X"), ToUnityY(location.Value<int>("Y"), mapHeight)),
+                    location => new Vector2(location.Value<int>("X") + 0.5f, ToUnityY(location.Value<int>("Y"), mapHeight) + 0.5f),
                     StringComparer.OrdinalIgnoreCase);
 
             return entries.All(entry =>
@@ -555,7 +571,7 @@ namespace WismUnity.Playground
                 .Where(anchor => !string.IsNullOrWhiteSpace(anchor.Value<string>("AnchorId")))
                 .ToDictionary(
                     anchor => anchor.Value<string>("AnchorId"),
-                    anchor => new Vector2Int(anchor.Value<int>("X"), ToUnityY(anchor.Value<int>("Y"), mapHeight)),
+                    anchor => new Vector2(anchor.Value<int>("X"), ToUnityY(anchor.Value<int>("Y"), mapHeight)),
                     StringComparer.OrdinalIgnoreCase);
 
             return entries.All(entry =>
@@ -563,7 +579,42 @@ namespace WismUnity.Playground
                 PositionMatches(entry.transform.position, position));
         }
 
-        static bool PositionMatches(Vector3 actual, Vector2Int expected)
+        static bool CityMarkersAreRuntimeReady(IEnumerable<CityEntry> entries)
+        {
+            return entries.All(entry =>
+                entry.CompareTag("City") &&
+                entry.GetComponent<CityEntry>() != null &&
+                entry.GetComponent<SpriteRenderer>() != null);
+        }
+
+        static bool LocationMarkersAreRuntimeReady(IEnumerable<LocationEntry> entries)
+        {
+            return entries.All(entry =>
+                entry.CompareTag("Location") &&
+                entry.GetComponent<LocationEntry>() != null &&
+                entry.GetComponent<SpriteRenderer>() != null);
+        }
+
+        static bool CityFootprintsArePainted(Tilemap tilemap, IReadOnlyList<JObject> cities, int mapHeight)
+        {
+            return cities.All(city =>
+            {
+                var x = city.Value<int>("X");
+                var y = ToUnityY(city.Value<int>("Y"), mapHeight);
+                return tilemap.GetTile(new Vector3Int(x, y, 0)) is CityTile &&
+                       tilemap.GetTile(new Vector3Int(x + 1, y, 0)) is CityTile &&
+                       tilemap.GetTile(new Vector3Int(x, y - 1, 0)) is CityTile &&
+                       tilemap.GetTile(new Vector3Int(x + 1, y - 1, 0)) is CityTile;
+            });
+        }
+
+        static bool LocationTilesArePainted(Tilemap tilemap, IReadOnlyList<JObject> locations, int mapHeight)
+        {
+            return locations.All(location =>
+                tilemap.GetTile(new Vector3Int(location.Value<int>("X"), ToUnityY(location.Value<int>("Y"), mapHeight), 0)) is LocationTile);
+        }
+
+        static bool PositionMatches(Vector3 actual, Vector2 expected)
         {
             return Mathf.Approximately(actual.x, expected.x) &&
                    Mathf.Approximately(actual.y, expected.y);
@@ -614,6 +665,88 @@ namespace WismUnity.Playground
         static int ToUnityY(int sourceY, int mapHeight)
         {
             return mapHeight - 1 - sourceY;
+        }
+
+        static Vector3 GetCellCenter(Tilemap tilemap, Vector3Int cell)
+        {
+            var origin = tilemap.CellToWorld(cell);
+            return new Vector3(
+                origin.x + tilemap.cellSize.x * 0.5f,
+                origin.y + tilemap.cellSize.y * 0.5f,
+                origin.z);
+        }
+
+        static GameObject EnsureSceneContainer<T>(Scene scene, string name) where T : Component
+        {
+            var matches = FindSceneGameObjects(scene, name);
+            foreach (var match in matches)
+            {
+                UnityEngine.Object.DestroyImmediate(match);
+            }
+
+            var keeper = new GameObject(name);
+            SceneManager.MoveGameObjectToScene(keeper, scene);
+            keeper.AddComponent<T>();
+            return keeper;
+        }
+
+        static GameObject InstantiateMarker(GameObject prefab, Scene scene, Transform parent, string name)
+        {
+            var marker = prefab != null
+                ? PrefabUtility.InstantiatePrefab(prefab, scene) as GameObject
+                : new GameObject(name);
+
+            marker ??= new GameObject(name);
+            marker.name = name;
+            marker.transform.SetParent(parent, false);
+            return marker;
+        }
+
+        static GameObject GetCityMarkerPrefab(GameObject cityContainer)
+        {
+            return cityContainer.GetComponent<CityContainer>()?.CityPrefab
+                ?? AssetDatabase.LoadAssetAtPath<GameObject>(CityMarkerPrefabPath);
+        }
+
+        static GameObject GetLocationMarkerPrefab(string terrain)
+        {
+            return (terrain ?? string.Empty).ToLowerInvariant() switch
+            {
+                "library" => AssetDatabase.LoadAssetAtPath<GameObject>(LibraryMarkerPrefabPath),
+                "sage" => AssetDatabase.LoadAssetAtPath<GameObject>(SageMarkerPrefabPath),
+                "temple" => AssetDatabase.LoadAssetAtPath<GameObject>(TempleMarkerPrefabPath),
+                "tomb" => AssetDatabase.LoadAssetAtPath<GameObject>(TombMarkerPrefabPath),
+                _ => AssetDatabase.LoadAssetAtPath<GameObject>(RuinsMarkerPrefabPath)
+            };
+        }
+
+        static T EnsureComponent<T>(GameObject go) where T : Component
+        {
+            return go.GetComponent<T>() ?? go.AddComponent<T>();
+        }
+
+        static List<GameObject> FindSceneGameObjects(Scene scene, string name)
+        {
+            var matches = new List<GameObject>();
+            foreach (var root in scene.GetRootGameObjects())
+            {
+                FindNamedObjects(root.transform, name, matches);
+            }
+
+            return matches;
+        }
+
+        static void FindNamedObjects(Transform transform, string name, ICollection<GameObject> matches)
+        {
+            if (string.Equals(transform.name, name, StringComparison.OrdinalIgnoreCase))
+            {
+                matches.Add(transform.gameObject);
+            }
+
+            foreach (Transform child in transform)
+            {
+                FindNamedObjects(child, name, matches);
+            }
         }
 
         static Dictionary<string, TileBase> LoadTileAssets()


### PR DESCRIPTION
## Summary
- regenerate Illuria scene marker containers so there is one Cities container and one Locations container
- create prefab-backed city/location markers with runtime tags, entry components, and sprite renderers
- extend the world-scene verifier to catch duplicate containers, missing marker components, and marker-to-tile misalignment

## Validation
- Unity batchmode verifier: Illuria scene proof passed with 109x156 tiles, 80 city markers, 40 location markers, 64 site anchors, one Cities container, one Locations container, and marker alignment checks
- dotnet build WismClient\\WismClient.sln --configuration Release --nologo -v:minimal
- dotnet test WismClient\\WismClient.sln --configuration Release --no-build --nologo -v:minimal
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts\\check-boundaries.ps1