### PR TITLE
Center Illuria city scene markers

### DIFF
--- a/WismUnity/Assets/Scenes/Illuria.unity
+++ b/WismUnity/Assets/Scenes/Illuria.unity
@@ -144,23 +144,287 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7088d912908f9284a83960d7ba0e2b8f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &17868655
+--- !u!1001 &3121993
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Ohmsmouth
+      value: AkGiriel
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7
+      value: 29
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 124
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: AkGiriel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &3121994 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 3121993}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8041232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8041233}
+  - component: {fileID: 8041234}
+  m_Layer: 0
+  m_Name: S17W-32
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8041233
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8041232}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 60, y: 14, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8041234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8041232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-32
+  mapByteOffset: 30858
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &12686054
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Barthel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 115
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Barthel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &12686055 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 12686054}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &38921312
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 38921313}
+  - component: {fileID: 38921314}
+  m_Layer: 0
+  m_Name: S17W-05
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &38921313
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 38921312}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 14, y: 31, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &38921314
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 38921312}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-05
+  mapByteOffset: 27060
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &43397157
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Himelton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -210,255 +474,18 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Ohmsmouth
+      value: Himelton
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &17868656 stripped
+--- !u!4 &43397158 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 17868655}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &25881320
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Beleri
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 15
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 149
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Beleri
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &25881321 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 25881320}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &29706986
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 74.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 8.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_Name
-      value: TempleofMiridine
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: locationShortName
-      value: TempleofMiridine
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &29706987 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-    type: 3}
-  m_PrefabInstance: {fileID: 29706986}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &50456781
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Ungor
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 87
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 136
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Ungor
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &50456782 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 50456781}
+  m_PrefabInstance: {fileID: 43397157}
   m_PrefabAsset: {fileID: 0}
 --- !u!224 &55671594 stripped
 RectTransform:
@@ -549,28 +576,28 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &70628846
+--- !u!1001 &65808943
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Waybourne
+      value: Pareth
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 4
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 103
+      value: 139
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -615,36 +642,142 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Waybourne
+      value: Pareth
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &70628847 stripped
+--- !u!4 &65808944 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 70628846}
+  m_PrefabInstance: {fileID: 65808943}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &77911053
+--- !u!1 &79958438
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 79958439}
+  - component: {fileID: 79958440}
+  m_Layer: 0
+  m_Name: S17W-61
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &79958439
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 79958438}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 93, y: 56, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &79958440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 79958438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-61
+  mapByteOffset: 21768
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &85054329
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 85054330}
+  - component: {fileID: 85054331}
+  m_Layer: 0
+  m_Name: S17W-04
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &85054330
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85054329}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 12, y: 119, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &85054331
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 85054329}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-04
+  mapByteOffset: 7872
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &88583904
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 42.5
+      value: 76.5
       objectReference: {fileID: 0}
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 37.5
+      value: 114.5
       objectReference: {fileID: 0}
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -689,77 +822,24 @@ PrefabInstance:
     - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: locationShortName
-      value: TowerofDeath
+      value: DragonHalls
       objectReference: {fileID: 0}
     - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_Name
-      value: TowerofDeath
+      value: DragonHalls
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &77911054 stripped
+--- !u!4 &88583905 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 77911053}
+  m_PrefabInstance: {fileID: 88583904}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &81254369
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 81254370}
-  - component: {fileID: 81254371}
-  m_Layer: 0
-  m_Name: S17W-42
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &81254370
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 81254369}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 37, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &81254371
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 81254369}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-42
-  mapByteOffset: 25868
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
 --- !u!1 &93653616
 GameObject:
   m_ObjectHideFlags: 0
@@ -888,23 +968,187 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
---- !u!1001 &108376950
+--- !u!1001 &110276184
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: EmperorsCrypt
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: EmperorsCrypt
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &110276185 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 110276184}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &112097555
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: ArArak
+      value: Derridon
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 95
+      value: 55
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 83
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Derridon
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &112097556 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 112097555}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &122297116 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4866160464913853227, guid: b94260a4073957b4e8e6e2897bf96468,
+    type: 3}
+  m_PrefabInstance: {fileID: 4866160464934432823}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &126503377
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: DharKhosis
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 38
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -954,157 +1198,98 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: ArArak
+      value: DharKhosis
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &108376951 stripped
+--- !u!4 &126503378 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 108376950}
+  m_PrefabInstance: {fileID: 126503377}
   m_PrefabAsset: {fileID: 0}
---- !u!224 &122297116 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4866160464913853227, guid: b94260a4073957b4e8e6e2897bf96468,
-    type: 3}
-  m_PrefabInstance: {fileID: 4866160464934432823}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &126705776
+--- !u!1001 &137152484
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: BaladNaran
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 90
+      value: 93.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 51
+      value: 87.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DragontowerRuins
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_Name
-      value: BaladNaran
+      value: DragontowerRuins
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &126705777 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &137152485 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 126705776}
+  m_PrefabInstance: {fileID: 137152484}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &128346274
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 128346275}
-  - component: {fileID: 128346276}
-  m_Layer: 0
-  m_Name: S17W-14
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &128346275
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 128346274}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 23, y: 128, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &128346276
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 128346274}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-14
-  mapByteOffset: 5932
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
 --- !u!1 &149804620
 GameObject:
   m_ObjectHideFlags: 0
@@ -1241,6 +1426,138 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 6261160846310461488}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &162050405
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162050406}
+  - component: {fileID: 162050407}
+  m_Layer: 0
+  m_Name: S17W-18
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &162050406
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162050405}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 37, y: 69, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &162050407
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162050405}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-18
+  mapByteOffset: 18822
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &172182359
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 69.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 137.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: MirksDecay
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: MirksDecay
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &172182360 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 172182359}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &186682938
 GameObject:
   m_ObjectHideFlags: 0
@@ -1333,23 +1650,23 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 100, y: 100}
   m_EdgeRadius: 0
---- !u!1001 &199481285
+--- !u!1001 &192164813
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 24.5
+      value: 45.5
       objectReference: {fileID: 0}
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 33.5
+      value: 84.5
       objectReference: {fileID: 0}
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -1394,205 +1711,46 @@ PrefabInstance:
     - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: locationShortName
-      value: TheOldInn
+      value: NirnsCrypt
       objectReference: {fileID: 0}
     - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_Name
-      value: TheOldInn
+      value: NirnsCrypt
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &199481286 stripped
+--- !u!4 &192164814 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 199481285}
+  m_PrefabInstance: {fileID: 192164813}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &204114861
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 204114862}
-  - component: {fileID: 204114863}
-  m_Layer: 0
-  m_Name: S17W-54
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &204114862
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 204114861}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 89, y: 77, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &204114863
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 204114861}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-54
-  mapByteOffset: 17182
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &205536470
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 205536471}
-  - component: {fileID: 205536472}
-  m_Layer: 0
-  m_Name: S17W-26
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &205536471
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 205536470}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 52, y: 54, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &205536472
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 205536470}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-26
-  mapByteOffset: 22122
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &209138479
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 209138480}
-  - component: {fileID: 209138481}
-  m_Layer: 0
-  m_Name: S17W-31
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &209138480
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 209138479}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 57, y: 22, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &209138481
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 209138479}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-31
-  mapByteOffset: 29108
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &220138561
+--- !u!1001 &193082049
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Deserton
+      value: Upbourne
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 93
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 153
+      value: 92
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -1637,18 +1795,176 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Deserton
+      value: Upbourne
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &220138562 stripped
+--- !u!4 &193082050 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 220138561}
+  m_PrefabInstance: {fileID: 193082049}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &198587680
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: PaKur
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 76
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: PaKur
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &198587681 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 198587680}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &202521588
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: AlfarsGap
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 14
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: AlfarsGap
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &202521589 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 202521588}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &222812354
 GameObject:
@@ -1718,81 +2034,28 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &242299944
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 242299945}
-  - component: {fileID: 242299946}
-  m_Layer: 0
-  m_Name: S17W-28
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &242299945
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 242299944}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 55, y: 33, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &242299946
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 242299944}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-28
-  mapByteOffset: 26706
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &261949983
+--- !u!1001 &224153249
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Marton
+      value: Needleton
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 18
+      value: 57
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 109
+      value: 128
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -1837,41 +2100,41 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Marton
+      value: Needleton
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &261949984 stripped
+--- !u!4 &224153250 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 261949983}
+  m_PrefabInstance: {fileID: 224153249}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &273032722
+--- !u!1001 &233682455
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Quiesce
+      value: Ilnyr
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 15
+      value: 72
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 35
+      value: 62
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -1916,20 +2179,20 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Quiesce
+      value: Ilnyr
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &273032723 stripped
+--- !u!4 &233682456 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 273032722}
+  m_PrefabInstance: {fileID: 233682455}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &274702070
+--- !u!1 &238624481
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1937,44 +2200,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 274702071}
-  - component: {fileID: 274702072}
+  - component: {fileID: 238624482}
+  - component: {fileID: 238624483}
   m_Layer: 0
-  m_Name: S17W-24
+  m_Name: S17W-57
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &274702071
+--- !u!4 &238624482
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 274702070}
+  m_GameObject: {fileID: 238624481}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 50, y: 17, z: 0}
+  m_LocalPosition: {x: 91, y: 56, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &274702072
+--- !u!114 &238624483
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 274702070}
+  m_GameObject: {fileID: 238624481}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-24
-  mapByteOffset: 30184
+  siteAnchorId: S17W-57
+  mapByteOffset: 21764
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -1982,18 +2245,18 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1001 &286589482
+--- !u!1001 &239916456
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Greenweigh
+      value: Zhoran
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -2003,7 +2266,7 @@ PrefabInstance:
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 102
+      value: 94
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -2048,20 +2311,105 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Greenweigh
+      value: Zhoran
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &286589483 stripped
+--- !u!4 &239916457 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 286589482}
+  m_PrefabInstance: {fileID: 239916456}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &287395395
+--- !u!1001 &264364380
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 12.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 101.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: HarvestStone
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: HarvestStone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &264364381 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 264364380}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &315151239 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2107104533398651432, guid: 383aa00ac70095c479df23749f4cd40b,
+    type: 3}
+  m_PrefabInstance: {fileID: 2107104533688570287}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &320295934
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -2069,8 +2417,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 287395396}
-  - component: {fileID: 287395397}
+  - component: {fileID: 320295935}
+  - component: {fileID: 320295936}
   m_Layer: 0
   m_Name: S17W-29
   m_TagString: Untagged
@@ -2078,28 +2426,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &287395396
+--- !u!4 &320295935
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 287395395}
+  m_GameObject: {fileID: 320295934}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 56, y: 17, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &287395397
+--- !u!114 &320295936
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 287395395}
+  m_GameObject: {fileID: 320295934}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -2114,91 +2462,6 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!224 &315151239 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 2107104533398651432, guid: 383aa00ac70095c479df23749f4cd40b,
-    type: 3}
-  m_PrefabInstance: {fileID: 2107104533688570287}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &333493213
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 102.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 154.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_Name
-      value: TempleofEmrik
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: locationShortName
-      value: TempleofEmrik
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &333493214 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-    type: 3}
-  m_PrefabInstance: {fileID: 333493213}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &336097773 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7972507522663850382, guid: eef716d4c750af84b9ab4224489408c5,
@@ -2323,12 +2586,171 @@ MonoBehaviour:
   xMaxClamp: 75
   yMinClamp: 7.5
   yMaxClamp: 73
+--- !u!1 &336941997
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 336941998}
+  - component: {fileID: 336941999}
+  m_Layer: 0
+  m_Name: S17W-62
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &336941998
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 336941997}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 95, y: 139, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &336941999
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 336941997}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-62
+  mapByteOffset: 3678
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
 --- !u!224 &340544440 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 2475077301827628559, guid: 4fecfc7429f3fdd47ba48c8b603d55bc,
     type: 3}
   m_PrefabInstance: {fileID: 2475077302033917367}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &342016550
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 342016551}
+  - component: {fileID: 342016552}
+  m_Layer: 0
+  m_Name: S17W-59
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &342016551
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 342016550}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 92, y: 125, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &342016552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 342016550}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-59
+  mapByteOffset: 6724
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &343968262
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 343968263}
+  - component: {fileID: 343968264}
+  m_Layer: 0
+  m_Name: S17W-15
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &343968263
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 343968262}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 23, y: 116, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &343968264
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 343968262}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-15
+  mapByteOffset: 8548
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
 --- !u!1 &344619232 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5039577765313823726, guid: 1e063c8ed0bc935418d127a1372571d0,
@@ -2341,160 +2763,28 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 5039577764986272526}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &371174453
+--- !u!1001 &366403771
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 18.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 102.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: EmperorsCrypt
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: EmperorsCrypt
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &371174454 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 371174453}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &386410571
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 386410572}
-  - component: {fileID: 386410573}
-  m_Layer: 0
-  m_Name: S17W-25
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &386410572
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 386410571}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 52, y: 112, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &386410573
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 386410571}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-25
-  mapByteOffset: 9478
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &417777433
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Elvallie
+      value: Ungor
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 41
+      value: 88
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 30
+      value: 137
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -2539,18 +2829,387 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Elvallie
+      value: Ungor
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &417777434 stripped
+--- !u!4 &366403772 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 417777433}
+  m_PrefabInstance: {fileID: 366403771}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &395984433
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Galin
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 42
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Galin
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &395984434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 395984433}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &399299942
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Deserton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 94
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 154
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Deserton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &399299943 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 399299942}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &402520173
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Vival
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 136
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Vival
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &402520174 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 402520173}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &416142520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 416142521}
+  - component: {fileID: 416142522}
+  m_Layer: 0
+  m_Name: S17W-60
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &416142521
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 416142520}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 92, y: 77, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &416142522
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 416142520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-60
+  mapByteOffset: 17188
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &418765799
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 86.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 105.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: HallsofChaos
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: HallsofChaos
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &418765800 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 418765799}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &418848444 stripped
 Transform:
@@ -2558,13 +3217,585 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 3274794878370800250}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &425138699
+--- !u!1 &433104251
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 433104252}
+  - component: {fileID: 433104253}
+  m_Layer: 0
+  m_Name: S17W-26
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &433104252
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433104251}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52, y: 54, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &433104253
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433104251}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-26
+  mapByteOffset: 22122
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &433237537
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 433237538}
+  - component: {fileID: 433237539}
+  m_Layer: 0
+  m_Name: S17W-63
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &433237538
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433237537}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 95, y: 65, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &433237539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 433237537}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-63
+  mapByteOffset: 19810
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &445483886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 445483887}
+  - component: {fileID: 445483888}
+  m_Layer: 0
+  m_Name: S17W-33
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &445483887
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 445483886}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 63, y: 44, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &445483888
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 445483886}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-33
+  mapByteOffset: 24324
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &479506526
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 42.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 37.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: TowerofDeath
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: TowerofDeath
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &479506527 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 479506526}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &483802724
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Cragmorton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 35
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Cragmorton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &483802725 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 483802724}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &487340218
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: RuinsofHaviel
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: RuinsofHaviel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &487340219 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 487340218}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &520247073 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 217013594807357015, guid: 0a0a91344e92c8242a6385b9ec6242a0,
+    type: 3}
+  m_PrefabInstance: {fileID: 217013594619845643}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &528182182
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 100.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 46.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: Guardian
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: Guardian
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &528182183 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 528182182}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &545365505
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Khamar
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 93
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Khamar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &545365506 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 545365505}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &546283580 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3274794878898324038, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
+    type: 3}
+  m_PrefabInstance: {fileID: 3274794878370800250}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &548277510
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
@@ -2631,527 +3862,78 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &425138700 stripped
+--- !u!4 &548277511 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
     type: 3}
-  m_PrefabInstance: {fileID: 425138699}
+  m_PrefabInstance: {fileID: 548277510}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &438705025
-PrefabInstance:
+--- !u!1 &567445006
+GameObject:
   m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Tirfing
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 68
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 143
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Tirfing
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &438705026 stripped
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 567445007}
+  - component: {fileID: 567445008}
+  m_Layer: 0
+  m_Name: S17W-07
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &567445007
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567445006}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 15, y: 28, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &567445008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 567445006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-07
+  mapByteOffset: 27716
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!114 &572604740 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3274794878943241022, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
     type: 3}
-  m_PrefabInstance: {fileID: 438705025}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &458103044
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 458103045}
-  - component: {fileID: 458103046}
-  m_Layer: 0
-  m_Name: S17W-45
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &458103045
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 458103044}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 73, y: 32, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &458103046
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 458103044}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-45
-  mapByteOffset: 26960
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &463877895
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 7.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 121.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: GreyportRuins
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: GreyportRuins
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &463877896 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 463877895}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &466131450
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 466131451}
-  - component: {fileID: 466131452}
-  m_Layer: 0
-  m_Name: S17W-37
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &466131451
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 466131450}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 70, y: 97, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &466131452
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 466131450}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-37
-  mapByteOffset: 12784
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &466475493
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Khamar
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 39
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 92
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Khamar
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &466475494 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 466475493}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &482302818
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 482302819}
-  - component: {fileID: 482302820}
-  m_Layer: 0
-  m_Name: S17W-18
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &482302819
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 482302818}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 37, y: 69, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &482302820
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 482302818}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-18
-  mapByteOffset: 18822
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &498158719
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 498158720}
-  - component: {fileID: 498158721}
-  m_Layer: 0
-  m_Name: S17W-12
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &498158720
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 498158719}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 22, y: 30, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &498158721
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 498158719}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-12
-  mapByteOffset: 27294
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &501127552
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 501127553}
-  - component: {fileID: 501127554}
-  m_Layer: 0
-  m_Name: S17W-39
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &501127553
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 501127552}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 114, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &501127554
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 501127552}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-39
-  mapByteOffset: 9082
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!114 &520247073 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 217013594807357015, guid: 0a0a91344e92c8242a6385b9ec6242a0,
-    type: 3}
-  m_PrefabInstance: {fileID: 217013594619845643}
+  m_PrefabInstance: {fileID: 3274794878370800250}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Script: {fileID: 11500000, guid: af7e80bce9c65884dace92099102a361, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &522548136
+--- !u!1 &589504810
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -3159,148 +3941,126 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 522548138}
-  - component: {fileID: 522548137}
+  - component: {fileID: 589504811}
+  - component: {fileID: 589504812}
   m_Layer: 0
-  m_Name: Cities
+  m_Name: S17W-42
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &522548137
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 522548136}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa2d8012b36e9824a897a0799127ab63, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::CityContainer
-  ImportCitesFromTilemap: 0
-  Reset: 0
-  CityPrefab: {fileID: 0}
-  TotalCities: 0
---- !u!4 &522548138
+--- !u!4 &589504811
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 522548136}
+  m_GameObject: {fileID: 589504810}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 72, y: 37, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 828835894}
-  - {fileID: 814302603}
-  - {fileID: 771466589}
-  - {fileID: 1461372681}
-  - {fileID: 2119169035}
-  - {fileID: 2046591604}
-  - {fileID: 1350915013}
-  - {fileID: 1773672588}
-  - {fileID: 1125684620}
-  - {fileID: 1175321533}
-  - {fileID: 286589483}
-  - {fileID: 628227965}
-  - {fileID: 572843665}
-  - {fileID: 779035665}
-  - {fileID: 1641722178}
-  - {fileID: 1214904168}
-  - {fileID: 50456782}
-  - {fileID: 2124823450}
-  - {fileID: 70628847}
-  - {fileID: 1270877303}
-  - {fileID: 745154071}
-  - {fileID: 1356154759}
-  - {fileID: 569232123}
-  - {fileID: 261949984}
-  - {fileID: 1837246515}
-  - {fileID: 998852610}
-  - {fileID: 417777434}
-  - {fileID: 531606096}
-  - {fileID: 25881321}
-  - {fileID: 1892315349}
-  - {fileID: 1376430228}
-  - {fileID: 975471614}
-  - {fileID: 949560577}
-  - {fileID: 1055096887}
-  - {fileID: 1259629121}
-  - {fileID: 1179164401}
-  - {fileID: 1837989429}
-  - {fileID: 466475494}
-  - {fileID: 1371245909}
-  - {fileID: 108376951}
-  - {fileID: 1814254251}
-  - {fileID: 883933797}
-  - {fileID: 1751642076}
-  - {fileID: 708313241}
-  - {fileID: 2013534730}
-  - {fileID: 2087984152}
-  - {fileID: 1440940004}
-  - {fileID: 2142612331}
-  - {fileID: 2094990718}
-  - {fileID: 1879778975}
-  - {fileID: 1427107418}
-  - {fileID: 1546381381}
-  - {fileID: 783572360}
-  - {fileID: 1878608646}
-  - {fileID: 1311301817}
-  - {fileID: 1241980233}
-  - {fileID: 2067220331}
-  - {fileID: 702612011}
-  - {fileID: 17868656}
-  - {fileID: 530957441}
-  - {fileID: 2116387897}
-  - {fileID: 1174254732}
-  - {fileID: 813030337}
-  - {fileID: 1553444547}
-  - {fileID: 1954145112}
-  - {fileID: 220138562}
-  - {fileID: 126705777}
-  - {fileID: 1605303584}
-  - {fileID: 1469436229}
-  - {fileID: 1077498933}
-  - {fileID: 2060731880}
-  - {fileID: 2065589677}
-  - {fileID: 1523166802}
-  - {fileID: 1880705473}
-  - {fileID: 1307153501}
-  - {fileID: 273032723}
-  - {fileID: 438705026}
-  - {fileID: 989907369}
-  - {fileID: 1247998485}
-  - {fileID: 1552600068}
-  m_Father: {fileID: 0}
+  m_Children: []
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &530957440
+--- !u!114 &589504812
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 589504810}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-42
+  mapByteOffset: 25868
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &597160006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 597160007}
+  - component: {fileID: 597160008}
+  m_Layer: 0
+  m_Name: S17W-64
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &597160007
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 597160006}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 97, y: 115, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &597160008
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 597160006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-64
+  mapByteOffset: 8914
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &600530330
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Meneloth
+      value: Varde
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 67
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 117
+      value: 34
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -3345,270 +4105,26 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Meneloth
+      value: Varde
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &530957441 stripped
+--- !u!4 &600530331 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 530957440}
+  m_PrefabInstance: {fileID: 600530330}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &531606095
+--- !u!1001 &603011720
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Dunethel
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 83
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Dunethel
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &531606096 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 531606095}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &542280877
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 542280878}
-  - component: {fileID: 542280879}
-  m_Layer: 0
-  m_Name: S17W-35
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &542280878
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 542280877}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 67, y: 14, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &542280879
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 542280877}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-35
-  mapByteOffset: 30872
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!4 &546283580 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 3274794878898324038, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
-    type: 3}
-  m_PrefabInstance: {fileID: 3274794878370800250}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &552500930
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 552500931}
-  - component: {fileID: 552500932}
-  m_Layer: 0
-  m_Name: S17W-02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &552500931
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 552500930}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5, y: 132, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &552500932
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 552500930}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-02
-  mapByteOffset: 5024
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &562312098
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 562312099}
-  - component: {fileID: 562312100}
-  m_Layer: 0
-  m_Name: S17W-59
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &562312099
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 562312098}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 92, y: 125, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &562312100
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 562312098}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-59
-  mapByteOffset: 6724
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &568907617
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -3675,260 +4191,11 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &568907618 stripped
+--- !u!4 &603011721 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 568907617}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &569232122
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Ubar
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 48
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 69
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Ubar
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &569232123 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 569232122}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &572604740 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3274794878943241022, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
-    type: 3}
-  m_PrefabInstance: {fileID: 3274794878370800250}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: af7e80bce9c65884dace92099102a361, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!1001 &572843664
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Kor
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 100
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 64
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Kor
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &572843665 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 572843664}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &609163787
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 93.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 87.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: DragontowerRuins
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: DragontowerRuins
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &609163788 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 609163787}
+  m_PrefabInstance: {fileID: 603011720}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &612679814
 GameObject:
@@ -4047,815 +4314,23 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 612679814}
   m_CullTransparentMesh: 1
---- !u!1 &615101243
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 615101244}
-  - component: {fileID: 615101245}
-  m_Layer: 0
-  m_Name: S17W-21
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &615101244
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 615101243}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 40, y: 74, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &615101245
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 615101243}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-21
-  mapByteOffset: 17738
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &628227964
+--- !u!1001 &625619092
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Kazrak
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 58
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 64
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Kazrak
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &628227965 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 628227964}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &642682789
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 642682790}
-  - component: {fileID: 642682791}
-  m_Layer: 0
-  m_Name: S17W-40
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &642682790
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642682789}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 112, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &642682791
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 642682789}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-40
-  mapByteOffset: 9518
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &645376915
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 76.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 114.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: DragonHalls
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: DragonHalls
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &645376916 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 645376915}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &647529785
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 647529786}
-  - component: {fileID: 647529787}
-  m_Layer: 0
-  m_Name: S17W-61
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &647529786
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 647529785}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 93, y: 56, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &647529787
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 647529785}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-61
-  mapByteOffset: 21768
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &651858884
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 86.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 105.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: HallsofChaos
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: HallsofChaos
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &651858885 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 651858884}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &655109381
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 655109382}
-  - component: {fileID: 655109383}
-  m_Layer: 0
-  m_Name: S17W-38
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &655109382
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 655109381}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 70, y: 18, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &655109383
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 655109381}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-38
-  mapByteOffset: 30006
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &673920028
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 673920029}
-  - component: {fileID: 673920030}
-  m_Layer: 0
-  m_Name: S17W-03
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &673920029
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673920028}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 7, y: 152, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &673920030
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 673920028}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-03
-  mapByteOffset: 668
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &700803660
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 18.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 22.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: ThroneofHoran
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: ThroneofHoran
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &700803661 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 700803660}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &702612010
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Darclan
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 91
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 99
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Darclan
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &702612011 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 702612010}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &708313240
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Dethal
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 98
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 103
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Dethal
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &708313241 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 708313240}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &732485646
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 732485647}
-  - component: {fileID: 732485648}
-  m_Layer: 0
-  m_Name: S17W-53
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &732485647
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 732485646}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 88, y: 112, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &732485648
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 732485646}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-53
-  mapByteOffset: 9550
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &737233882
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 38.5
+      value: 72.5
       objectReference: {fileID: 0}
     - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 62.5
+      value: 98.5
       objectReference: {fileID: 0}
     - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
@@ -4900,1154 +4375,31 @@ PrefabInstance:
     - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_Name
-      value: GreatLibrary
+      value: SeeroftheRiver
       objectReference: {fileID: 0}
     - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: locationShortName
-      value: GreatLibrary
+      value: SeeroftheRiver
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &737233883 stripped
+--- !u!4 &625619093 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
     type: 3}
-  m_PrefabInstance: {fileID: 737233882}
+  m_PrefabInstance: {fileID: 625619092}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &745154070
+--- !u!1001 &629228666
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Deephallow
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 60
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 124
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Deephallow
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &745154071 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 745154070}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &771466588
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Varde
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 33
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Varde
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &771466589 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 771466588}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &779035664
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Vival
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 135
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Vival
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &779035665 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 779035664}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &783572359
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Gimlad
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 89
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 67
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Gimlad
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &783572360 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 783572359}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &804887380
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 55.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 119.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: NirnsDeep
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: NirnsDeep
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &804887381 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 804887380}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &813030336
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Fleymark
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 68
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 81
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Fleymark
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &813030337 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 813030336}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &814302602
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: PaKur
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 86
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 75
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: PaKur
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &814302603 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 814302602}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &818195350
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 818195351}
-  m_Layer: 0
-  m_Name: SiteAnchors
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &818195351
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 818195350}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1337929245}
-  - {fileID: 552500931}
-  - {fileID: 673920029}
-  - {fileID: 1321070472}
-  - {fileID: 908796586}
-  - {fileID: 1923041882}
-  - {fileID: 2086883951}
-  - {fileID: 2051036623}
-  - {fileID: 1829056166}
-  - {fileID: 1792841183}
-  - {fileID: 1577780678}
-  - {fileID: 498158720}
-  - {fileID: 1108912329}
-  - {fileID: 128346275}
-  - {fileID: 1638157248}
-  - {fileID: 1419864815}
-  - {fileID: 1969623974}
-  - {fileID: 482302819}
-  - {fileID: 1114565599}
-  - {fileID: 1223500151}
-  - {fileID: 615101244}
-  - {fileID: 1916110663}
-  - {fileID: 2132718336}
-  - {fileID: 274702071}
-  - {fileID: 386410572}
-  - {fileID: 205536471}
-  - {fileID: 992645251}
-  - {fileID: 242299945}
-  - {fileID: 287395396}
-  - {fileID: 1839947480}
-  - {fileID: 209138480}
-  - {fileID: 955578233}
-  - {fileID: 958970827}
-  - {fileID: 1727064488}
-  - {fileID: 542280878}
-  - {fileID: 1235820162}
-  - {fileID: 466131451}
-  - {fileID: 655109382}
-  - {fileID: 501127553}
-  - {fileID: 642682790}
-  - {fileID: 1874487367}
-  - {fileID: 81254370}
-  - {fileID: 857805142}
-  - {fileID: 1405312980}
-  - {fileID: 458103045}
-  - {fileID: 1267698130}
-  - {fileID: 1488393897}
-  - {fileID: 1875173423}
-  - {fileID: 1464920109}
-  - {fileID: 987054033}
-  - {fileID: 1660598210}
-  - {fileID: 1281269319}
-  - {fileID: 732485647}
-  - {fileID: 204114862}
-  - {fileID: 1457457847}
-  - {fileID: 1447443200}
-  - {fileID: 1491074898}
-  - {fileID: 982258805}
-  - {fileID: 562312099}
-  - {fileID: 1331182061}
-  - {fileID: 647529786}
-  - {fileID: 865407175}
-  - {fileID: 985301253}
-  - {fileID: 1080371608}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &828835893
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Tasme
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 42
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Tasme
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &828835894 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 828835893}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &857805141
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 857805142}
-  - component: {fileID: 857805143}
-  m_Layer: 0
-  m_Name: S17W-43
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &857805142
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 857805141}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 26, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &857805143
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 857805141}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-43
-  mapByteOffset: 28266
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &865215781
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 100.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 93.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: CryptofMolok
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: CryptofMolok
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &865215782 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 865215781}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &865407174
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 865407175}
-  - component: {fileID: 865407176}
-  m_Layer: 0
-  m_Name: S17W-62
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &865407175
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 865407174}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 95, y: 139, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &865407176
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 865407174}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-62
-  mapByteOffset: 3678
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &883933796
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Ilnyr
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 71
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 61
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Ilnyr
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &883933797 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 883933796}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &885622283
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 45.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 84.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: NirnsCrypt
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: NirnsCrypt
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &885622284 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 885622283}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &908796585
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 908796586}
-  - component: {fileID: 908796587}
-  m_Layer: 0
-  m_Name: S17W-05
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &908796586
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 908796585}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 14, y: 31, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &908796587
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 908796585}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-05
-  mapByteOffset: 27060
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &941280968
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -6114,11 +4466,2416 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &941280969 stripped
+--- !u!4 &629228667 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 941280968}
+  m_PrefabInstance: {fileID: 629228666}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &631875744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 631875745}
+  - component: {fileID: 631875746}
+  m_Layer: 0
+  m_Name: S17W-37
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &631875745
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 631875744}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 70, y: 97, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &631875746
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 631875744}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-37
+  mapByteOffset: 12784
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &645087002
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gildenhome
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gildenhome
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &645087003 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 645087002}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &648021517
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 63
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Marthos
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &648021518 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 648021517}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &660974935
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Fleymark
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 69
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 82
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Fleymark
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &660974936 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 660974935}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &682159762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 682159763}
+  - component: {fileID: 682159764}
+  m_Layer: 0
+  m_Name: S17W-40
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &682159763
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682159762}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 72, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &682159764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 682159762}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-40
+  mapByteOffset: 9518
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &689356270
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 689356271}
+  - component: {fileID: 689356272}
+  m_Layer: 0
+  m_Name: S17W-20
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &689356271
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689356270}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 38, y: 88, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &689356272
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689356270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-20
+  mapByteOffset: 14682
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &693269986
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Darclan
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 92
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Darclan
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &693269987 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 693269986}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &708351075
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 11.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 38.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: GoldenLibrary
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: GoldenLibrary
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &708351076 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 708351075}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &718562108
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 718562109}
+  - component: {fileID: 718562110}
+  m_Layer: 0
+  m_Name: S17W-58
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &718562109
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718562108}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 91, y: 45, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &718562110
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 718562108}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-58
+  mapByteOffset: 24162
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &742175814
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 742175815}
+  - component: {fileID: 742175816}
+  m_Layer: 0
+  m_Name: S17W-43
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &742175815
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 742175814}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 72, y: 26, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &742175816
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 742175814}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-43
+  mapByteOffset: 28266
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &748447081
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Minbourne
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 71
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Minbourne
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &748447082 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 748447081}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &748855938
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Vernon
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 49
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 66
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Vernon
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &748855939 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 748855938}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &767715875
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Wellmore
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 52
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Wellmore
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &767715876 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 767715875}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &770135951
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gork
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 87
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gork
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &770135952 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 770135951}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &786905897
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Upway
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 47
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 102
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Upway
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &786905898 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 786905897}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &809944867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 809944868}
+  - component: {fileID: 809944869}
+  m_Layer: 0
+  m_Name: S17W-03
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &809944868
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 809944867}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 7, y: 152, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &809944869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 809944867}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-03
+  mapByteOffset: 668
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &812748060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 812748061}
+  - component: {fileID: 812748062}
+  m_Layer: 0
+  m_Name: S17W-25
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &812748061
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812748060}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 52, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &812748062
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812748060}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-25
+  mapByteOffset: 9478
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &814254388
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Jessarton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 97
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Jessarton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &814254389 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 814254388}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &817785888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 817785890}
+  - component: {fileID: 817785889}
+  m_Layer: 0
+  m_Name: Locations
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &817785889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 817785888}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a860770c2175fa4db0bef3e7b3b5a2f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationContainer
+  ImportLocationsFromTilemap: 0
+  Reset: 0
+  LibraryPrefab: {fileID: 0}
+  RuinsPrefab: {fileID: 0}
+  SagePrefab: {fileID: 0}
+  TemplePrefab: {fileID: 0}
+  TombPrefab: {fileID: 0}
+  TotalLocations: 0
+--- !u!4 &817785890
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 817785888}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 548277511}
+  - {fileID: 625619093}
+  - {fileID: 1834885222}
+  - {fileID: 708351076}
+  - {fileID: 870760676}
+  - {fileID: 1821677852}
+  - {fileID: 2145851602}
+  - {fileID: 2133646698}
+  - {fileID: 1344401796}
+  - {fileID: 110276185}
+  - {fileID: 264364381}
+  - {fileID: 629228667}
+  - {fileID: 1937023540}
+  - {fileID: 1677546729}
+  - {fileID: 192164814}
+  - {fileID: 863808493}
+  - {fileID: 172182360}
+  - {fileID: 861628237}
+  - {fileID: 88583905}
+  - {fileID: 1798985605}
+  - {fileID: 1262375932}
+  - {fileID: 418765800}
+  - {fileID: 137152485}
+  - {fileID: 1294836018}
+  - {fileID: 2000980866}
+  - {fileID: 1315685459}
+  - {fileID: 853472092}
+  - {fileID: 1244536768}
+  - {fileID: 479506527}
+  - {fileID: 487340219}
+  - {fileID: 1281793501}
+  - {fileID: 1017989156}
+  - {fileID: 2018454232}
+  - {fileID: 1388347262}
+  - {fileID: 1798533380}
+  - {fileID: 528182183}
+  - {fileID: 603011721}
+  - {fileID: 1002459458}
+  - {fileID: 1783881200}
+  - {fileID: 1735097268}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &838379362
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: CitadelofIce
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 64
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 74
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: CitadelofIce
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &838379363 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 838379362}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &842641683
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 842641684}
+  - component: {fileID: 842641685}
+  m_Layer: 0
+  m_Name: S17W-09
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &842641684
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842641683}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 18, y: 113, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &842641685
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 842641683}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-09
+  mapByteOffset: 9192
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &853472091
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 29.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: ThroneofBalnor
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: ThroneofBalnor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &853472092 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 853472091}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &861628236
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 89.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: WizardsHearth
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: WizardsHearth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &861628237 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 861628236}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &863808492
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 55.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 119.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: NirnsDeep
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: NirnsDeep
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &863808493 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 863808492}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &870760675
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 38.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 62.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: GreatLibrary
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: GreatLibrary
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &870760676 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 870760675}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &871083409
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 871083410}
+  - component: {fileID: 871083411}
+  m_Layer: 0
+  m_Name: S17W-13
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &871083410
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 871083409}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 22, y: 28, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &871083411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 871083409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-13
+  mapByteOffset: 27730
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &872835107
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 872835108}
+  - component: {fileID: 872835109}
+  m_Layer: 0
+  m_Name: S17W-08
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &872835108
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 872835107}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 18, y: 125, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &872835109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 872835107}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-08
+  mapByteOffset: 6576
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &889979153
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Kor
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 101
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 65
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Kor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &889979154 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 889979153}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &894916843
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 894916844}
+  - component: {fileID: 894916845}
+  m_Layer: 0
+  m_Name: S17W-46
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &894916844
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894916843}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 73, y: 29, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &894916845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 894916843}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-46
+  mapByteOffset: 27614
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &899312186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 899312187}
+  - component: {fileID: 899312188}
+  m_Layer: 0
+  m_Name: S17W-53
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &899312187
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899312186}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 88, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &899312188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 899312186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-53
+  mapByteOffset: 9550
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &910195321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910195322}
+  - component: {fileID: 910195323}
+  m_Layer: 0
+  m_Name: S17W-02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &910195322
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910195321}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5, y: 132, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &910195323
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910195321}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-02
+  mapByteOffset: 5024
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &910678731
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910678733}
+  - component: {fileID: 910678732}
+  m_Layer: 0
+  m_Name: Cities
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &910678732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910678731}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa2d8012b36e9824a897a0799127ab63, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::CityContainer
+  ImportCitesFromTilemap: 0
+  Reset: 0
+  CityPrefab: {fileID: 0}
+  TotalCities: 0
+--- !u!4 &910678733
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910678731}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2020521107}
+  - {fileID: 198587681}
+  - {fileID: 600530331}
+  - {fileID: 1467920233}
+  - {fileID: 1767064340}
+  - {fileID: 1626937739}
+  - {fileID: 814254389}
+  - {fileID: 767715876}
+  - {fileID: 1791786468}
+  - {fileID: 1058928537}
+  - {fileID: 1197166991}
+  - {fileID: 2077725659}
+  - {fileID: 889979154}
+  - {fileID: 402520174}
+  - {fileID: 1268708804}
+  - {fileID: 954124668}
+  - {fileID: 366403772}
+  - {fileID: 2028243815}
+  - {fileID: 1639071804}
+  - {fileID: 483802725}
+  - {fileID: 1853914091}
+  - {fileID: 2035028068}
+  - {fileID: 1048083506}
+  - {fileID: 2034334899}
+  - {fileID: 770135952}
+  - {fileID: 1517531142}
+  - {fileID: 1651814731}
+  - {fileID: 1372628046}
+  - {fileID: 970577740}
+  - {fileID: 1299098164}
+  - {fileID: 43397158}
+  - {fileID: 239916457}
+  - {fileID: 838379363}
+  - {fileID: 748447082}
+  - {fileID: 12686055}
+  - {fileID: 645087003}
+  - {fileID: 1569201719}
+  - {fileID: 545365506}
+  - {fileID: 1077728544}
+  - {fileID: 1469420216}
+  - {fileID: 1865566424}
+  - {fileID: 233682456}
+  - {fileID: 786905898}
+  - {fileID: 1365059679}
+  - {fileID: 65808944}
+  - {fileID: 979577172}
+  - {fileID: 1436900353}
+  - {fileID: 917277166}
+  - {fileID: 748855939}
+  - {fileID: 224153250}
+  - {fileID: 1919037698}
+  - {fileID: 193082050}
+  - {fileID: 1993007803}
+  - {fileID: 1640218701}
+  - {fileID: 1527006124}
+  - {fileID: 3121994}
+  - {fileID: 2031997039}
+  - {fileID: 693269987}
+  - {fileID: 1723312376}
+  - {fileID: 1815260980}
+  - {fileID: 1269000074}
+  - {fileID: 1458780985}
+  - {fileID: 660974936}
+  - {fileID: 2127245226}
+  - {fileID: 202521589}
+  - {fileID: 399299943}
+  - {fileID: 1373704926}
+  - {fileID: 924366434}
+  - {fileID: 1108027859}
+  - {fileID: 395984434}
+  - {fileID: 1131724147}
+  - {fileID: 112097556}
+  - {fileID: 126503378}
+  - {fileID: 1186087181}
+  - {fileID: 1610916720}
+  - {fileID: 1611408679}
+  - {fileID: 1983314403}
+  - {fileID: 648021518}
+  - {fileID: 1377456715}
+  - {fileID: 1322983165}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &917277165
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Troy
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 57
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Troy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &917277166 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 917277165}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &924366433
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gluk
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 85
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gluk
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &924366434 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 924366433}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &943228520
 GameObject:
@@ -6199,28 +6956,28 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 943228520}
   m_CullTransparentMesh: 1
---- !u!1001 &949560576
+--- !u!1001 &954124667
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: CitadelofIce
+      value: Carmel
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 63
+      value: 20
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 73
+      value: 85
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -6265,305 +7022,41 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: CitadelofIce
+      value: Carmel
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &949560577 stripped
+--- !u!4 &954124668 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 949560576}
+  m_PrefabInstance: {fileID: 954124667}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &953755985
+--- !u!1001 &970577739
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 72.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 98.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_Name
-      value: SeeroftheRiver
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: locationShortName
-      value: SeeroftheRiver
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &953755986 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-    type: 3}
-  m_PrefabInstance: {fileID: 953755985}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &955276894
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 57.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 74.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: DarkBarrows
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: DarkBarrows
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &955276895 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 955276894}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &955578232
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 955578233}
-  - component: {fileID: 955578234}
-  m_Layer: 0
-  m_Name: S17W-32
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &955578233
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 955578232}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 60, y: 14, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &955578234
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 955578232}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-32
-  mapByteOffset: 30858
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &958970826
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 958970827}
-  - component: {fileID: 958970828}
-  m_Layer: 0
-  m_Name: S17W-33
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &958970827
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 958970826}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 63, y: 44, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &958970828
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 958970826}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-33
-  mapByteOffset: 24324
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &975471613
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Zhoran
+      value: Beleri
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 93
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -6608,327 +7101,41 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Zhoran
+      value: Beleri
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &975471614 stripped
+--- !u!4 &970577740 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 975471613}
+  m_PrefabInstance: {fileID: 970577739}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &982258804
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 982258805}
-  - component: {fileID: 982258806}
-  m_Layer: 0
-  m_Name: S17W-58
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &982258805
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 982258804}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91, y: 45, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &982258806
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 982258804}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-58
-  mapByteOffset: 24162
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &985301252
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 985301253}
-  - component: {fileID: 985301254}
-  m_Layer: 0
-  m_Name: S17W-63
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &985301253
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 985301252}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 95, y: 65, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &985301254
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 985301252}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-63
-  mapByteOffset: 19810
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &987054032
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 987054033}
-  - component: {fileID: 987054034}
-  m_Layer: 0
-  m_Name: S17W-50
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &987054033
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 987054032}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 112, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &987054034
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 987054032}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-50
-  mapByteOffset: 9528
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &989907368
+--- !u!1001 &979577171
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 62
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Marthos
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &989907369 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 989907368}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &992645250
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 992645251}
-  - component: {fileID: 992645252}
-  m_Layer: 0
-  m_Name: S17W-27
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &992645251
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 992645250}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 54, y: 54, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &992645252
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 992645250}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-27
-  mapByteOffset: 22126
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &998852609
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Garom
+      value: Argenthorn
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 87
+      value: 43
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 40
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -6973,26 +7180,185 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Garom
+      value: Argenthorn
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &998852610 stripped
+--- !u!4 &979577172 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 998852609}
+  m_PrefabInstance: {fileID: 979577171}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1026372773
+--- !u!1 &999549707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 999549708}
+  - component: {fileID: 999549709}
+  m_Layer: 0
+  m_Name: S17W-51
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &999549708
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 999549707}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 81, y: 59, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &999549709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 999549707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-51
+  mapByteOffset: 21090
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1001371042
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1001371043}
+  - component: {fileID: 1001371044}
+  m_Layer: 0
+  m_Name: S17W-49
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1001371043
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001371042}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 77, y: 114, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1001371044
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1001371042}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-49
+  mapByteOffset: 9092
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1002437173
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1002437174}
+  - component: {fileID: 1002437175}
+  m_Layer: 0
+  m_Name: S17W-01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1002437174
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002437173}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4, y: 146, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1002437175
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1002437173}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-01
+  mapByteOffset: 1970
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1002459457
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -7059,11 +7425,90 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1026372774 stripped
+--- !u!4 &1002459458 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 1026372773}
+  m_PrefabInstance: {fileID: 1002459457}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1017989155
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 69.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 23.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DawnStone
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DawnStone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1017989156 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1017989155}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1031883957
 GameObject:
@@ -7140,31 +7585,31 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1031883957}
   m_CullTransparentMesh: 1
---- !u!1001 &1055096886
+--- !u!1001 &1048083505
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Minbourne
+      value: Ubar
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
+      value: 49
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
       value: 70
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 148
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
@@ -7206,41 +7651,41 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Minbourne
+      value: Ubar
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1055096887 stripped
+--- !u!4 &1048083506 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1055096886}
+  m_PrefabInstance: {fileID: 1048083505}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1077498932
+--- !u!1001 &1058928536
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Galin
+      value: Duinoth
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 41
+      value: 69
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 67
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -7285,205 +7730,257 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Galin
+      value: Duinoth
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1077498933 stripped
+--- !u!4 &1058928537 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1077498932}
+  m_PrefabInstance: {fileID: 1058928536}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1080371607
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1080371608}
-  - component: {fileID: 1080371609}
-  m_Layer: 0
-  m_Name: S17W-64
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1080371608
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1080371607}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 97, y: 115, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1080371609
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1080371607}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-64
-  mapByteOffset: 8914
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1083960862
+--- !u!1001 &1077728543
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Stormheim
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 12.5
+      value: 20
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 101.5
+      value: 48
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: HarvestStone
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: HarvestStone
+      value: Stormheim
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1083960863 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1077728544 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1083960862}
+  m_PrefabInstance: {fileID: 1077728543}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1108912328
-GameObject:
+--- !u!1001 &1108027858
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1108912329}
-  - component: {fileID: 1108912330}
-  m_Layer: 0
-  m_Name: S17W-13
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1108912329
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1108912328}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 22, y: 28, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1108912330
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Amenal
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 141
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Amenal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1108027859 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1108027858}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1108912328}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-13
-  mapByteOffset: 27730
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1114565598
+--- !u!1001 &1131724146
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Herueth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 66
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Herueth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1131724147 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1131724146}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1152646979
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -7491,8 +7988,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1114565599}
-  - component: {fileID: 1114565600}
+  - component: {fileID: 1152646980}
+  - component: {fileID: 1152646981}
   m_Layer: 0
   m_Name: S17W-19
   m_TagString: Untagged
@@ -7500,28 +7997,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1114565599
+--- !u!4 &1152646980
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1114565598}
+  m_GameObject: {fileID: 1152646979}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 38, y: 111, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1114565600
+--- !u!114 &1152646981
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1114565598}
+  m_GameObject: {fileID: 1152646979}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -7536,110 +8033,137 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1001 &1125684619
+--- !u!1 &1166298026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1166298027}
+  - component: {fileID: 1166298028}
+  m_Layer: 0
+  m_Name: S17W-44
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1166298027
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166298026}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 73, y: 34, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1166298028
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1166298026}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-44
+  mapByteOffset: 26524
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1176539327
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1176539328}
+  - component: {fileID: 1176539329}
+  m_Layer: 0
+  m_Name: S17W-28
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1176539328
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1176539327}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 55, y: 33, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1176539329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1176539327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-28
+  mapByteOffset: 26706
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1186087180
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: AkEnlie
+      value: Maridun
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 20
+      value: 58
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 120
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: AkEnlie
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1125684620 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1125684619}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1174254731
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Malikor
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
       value: 98
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 117
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
@@ -7681,41 +8205,94 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Malikor
+      value: Maridun
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1174254732 stripped
+--- !u!4 &1186087181 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1174254731}
+  m_PrefabInstance: {fileID: 1186087180}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1175321532
+--- !u!1 &1194297033
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1194297034}
+  - component: {fileID: 1194297035}
+  m_Layer: 0
+  m_Name: S17W-27
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1194297034
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1194297033}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 54, y: 54, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1194297035
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1194297033}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-27
+  mapByteOffset: 22126
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1197166990
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Duinoth
+      value: Greenweigh
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 68
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 49
+      value: 103
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -7760,97 +8337,18 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Duinoth
+      value: Greenweigh
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1175321533 stripped
+--- !u!4 &1197166991 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1175321532}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1179164400
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Gildenhome
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 33
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 29
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Gildenhome
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1179164401 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1179164400}
+  m_PrefabInstance: {fileID: 1197166990}
   m_PrefabAsset: {fileID: 0}
 --- !u!850595691 &1200442662
 LightingSettings:
@@ -7919,165 +8417,7 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
   m_RespectSceneVisibilityWhenBakingGI: 0
---- !u!1001 &1200497009
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 37.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 10.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: DuskStone
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: DuskStone
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1200497010 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1200497009}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1214904167
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Carmel
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 84
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Carmel
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1214904168 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1214904167}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1223500150
+--- !u!1 &1236574096
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8085,44 +8425,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1223500151}
-  - component: {fileID: 1223500152}
+  - component: {fileID: 1236574097}
+  - component: {fileID: 1236574098}
   m_Layer: 0
-  m_Name: S17W-20
+  m_Name: S17W-23
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1223500151
+--- !u!4 &1236574097
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1223500150}
+  m_GameObject: {fileID: 1236574096}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 38, y: 88, z: 0}
+  m_LocalPosition: {x: 50, y: 19, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1223500152
+--- !u!114 &1236574098
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1223500150}
+  m_GameObject: {fileID: 1236574096}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-20
-  mapByteOffset: 14682
+  siteAnchorId: S17W-23
+  mapByteOffset: 29748
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -8130,7 +8470,7 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1235820161
+--- !u!1 &1243225849
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8138,8 +8478,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1235820162}
-  - component: {fileID: 1235820163}
+  - component: {fileID: 1243225850}
+  - component: {fileID: 1243225851}
   m_Layer: 0
   m_Name: S17W-36
   m_TagString: Untagged
@@ -8147,28 +8487,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1235820162
+--- !u!4 &1243225850
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1235820161}
+  m_GameObject: {fileID: 1243225849}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 70, y: 99, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1235820163
+--- !u!114 &1243225851
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1235820161}
+  m_GameObject: {fileID: 1243225849}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -8183,1648 +8523,13 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1001 &1241980232
+--- !u!1001 &1244536767
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: AkGiriel
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 28
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 123
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: AkGiriel
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1241980233 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1241980232}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1247998484
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Tal
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 51
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 148
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Tal
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1247998485 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1247998484}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1259629120
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Barthel
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 32
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 114
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Barthel
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1259629121 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1259629120}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1267698129
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1267698130}
-  - component: {fileID: 1267698131}
-  m_Layer: 0
-  m_Name: S17W-46
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1267698130
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1267698129}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 73, y: 29, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1267698131
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1267698129}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-46
-  mapByteOffset: 27614
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1270877302
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Cragmorton
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 34
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 89
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Cragmorton
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1270877303 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1270877302}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1270896110
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 16.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 56.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: NevDolar
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: NevDolar
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1270896111 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1270896110}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1281269318
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1281269319}
-  - component: {fileID: 1281269320}
-  m_Layer: 0
-  m_Name: S17W-52
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1281269319
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1281269318}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 84, y: 137, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1281269320
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1281269318}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-52
-  mapByteOffset: 4092
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1293150454
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 69.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 23.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: DawnStone
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: DawnStone
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1293150455 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1293150454}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1307153500
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Gunthang
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 32
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 124
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Gunthang
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1307153501 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1307153500}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1308561381
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 94.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 33.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: TombofNaar
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: TombofNaar
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1308561382 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1308561381}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1311301816
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Enmouth
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 7
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 115
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Enmouth
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1311301817 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1311301816}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1321070471
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1321070472}
-  - component: {fileID: 1321070473}
-  m_Layer: 0
-  m_Name: S17W-04
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1321070472
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1321070471}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 12, y: 119, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1321070473
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1321070471}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-04
-  mapByteOffset: 7872
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1331182060
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1331182061}
-  - component: {fileID: 1331182062}
-  m_Layer: 0
-  m_Name: S17W-60
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1331182061
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331182060}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 92, y: 77, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1331182062
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1331182060}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-60
-  mapByteOffset: 17188
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1337929244
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1337929245}
-  - component: {fileID: 1337929246}
-  m_Layer: 0
-  m_Name: S17W-01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1337929245
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1337929244}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 4, y: 146, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1337929246
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1337929244}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-01
-  mapByteOffset: 1970
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1350915012
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Jessarton
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 6
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 96
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Jessarton
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1350915013 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1350915012}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1356154758
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: AkFarzon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 33
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 120
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: AkFarzon
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1356154759 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1356154758}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1371245908
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Stormheim
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 19
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 47
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Stormheim
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1371245909 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1371245908}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1376430227
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Himelton
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 59
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Himelton
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1376430228 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1376430227}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1405312979
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1405312980}
-  - component: {fileID: 1405312981}
-  m_Layer: 0
-  m_Name: S17W-44
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1405312980
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1405312979}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 73, y: 34, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1405312981
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1405312979}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-44
-  mapByteOffset: 26524
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1413564458
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 68.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 89.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: WizardsHearth
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: WizardsHearth
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1413564459 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1413564458}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1419864814
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1419864815}
-  - component: {fileID: 1419864816}
-  m_Layer: 0
-  m_Name: S17W-16
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1419864815
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1419864814}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 27, y: 54, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1419864816
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1419864814}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-16
-  mapByteOffset: 22072
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1427107417
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: BanesCitadel
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 92
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 130
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: BanesCitadel
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1427107418 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1427107417}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1440940003
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Charling
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 48
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 33
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Charling
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1440940004 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1440940003}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1445124151
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -9891,448 +8596,19 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1445124152 stripped
+--- !u!4 &1244536768 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 1445124151}
+  m_PrefabInstance: {fileID: 1244536767}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1447443199
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1447443200}
-  - component: {fileID: 1447443201}
-  m_Layer: 0
-  m_Name: S17W-56
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1447443200
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1447443199}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91, y: 63, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1447443201
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1447443199}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-56
-  mapByteOffset: 20238
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1457457846
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1457457847}
-  - component: {fileID: 1457457848}
-  m_Layer: 0
-  m_Name: S17W-55
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1457457847
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1457457846}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 90, y: 43, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1457457848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1457457846}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-55
-  mapByteOffset: 24596
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1461372680
+--- !u!1001 &1262375931
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Khorfe
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 25
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Khorfe
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1461372681 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1461372680}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1464920108
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1464920109}
-  - component: {fileID: 1464920110}
-  m_Layer: 0
-  m_Name: S17W-49
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1464920109
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1464920108}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 114, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1464920110
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1464920108}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-49
-  mapByteOffset: 9092
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1469436228
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Amenal
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 12
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 140
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Amenal
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1469436229 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1469436228}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1488393896
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1488393897}
-  - component: {fileID: 1488393898}
-  m_Layer: 0
-  m_Name: S17W-47
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1488393897
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488393896}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 144, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1488393898
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1488393896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-47
-  mapByteOffset: 2552
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1491074897
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1491074898}
-  - component: {fileID: 1491074899}
-  m_Layer: 0
-  m_Name: S17W-57
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1491074898
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1491074897}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 91, y: 56, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1491074899
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1491074897}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-57
-  mapByteOffset: 21764
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1494044689 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6703045709133836705, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
-    type: 3}
-  m_PrefabInstance: {fileID: 3274794878370800250}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1503230851
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -10342,7 +8618,7 @@ PrefabInstance:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 46.5
+      value: 93.5
       objectReference: {fileID: 0}
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -10387,24 +8663,1971 @@ PrefabInstance:
     - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: locationShortName
-      value: Guardian
+      value: CryptofMolok
       objectReference: {fileID: 0}
     - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_Name
-      value: Guardian
+      value: CryptofMolok
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1503230852 stripped
+--- !u!4 &1262375932 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 1503230851}
+  m_PrefabInstance: {fileID: 1262375931}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1268708803
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Herzag
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 79
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Herzag
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1268708804 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1268708803}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1269000073
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Angbar
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 55
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 46
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Angbar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1269000074 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1269000073}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1281793500
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 37.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 10.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DuskStone
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DuskStone
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1281793501 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1281793500}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1294836017
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 56.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: NevDolar
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: NevDolar
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1294836018 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1294836017}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1299098163
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Thurtz
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 86
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 66
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Thurtz
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1299098164 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1299098163}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1315685458
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 18.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 22.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: ThroneofHoran
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: ThroneofHoran
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1315685459 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1315685458}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1322983164
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Loremark
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 44
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 23
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Loremark
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1322983165 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1322983164}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1326595392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1326595393}
+  - component: {fileID: 1326595394}
+  m_Layer: 0
+  m_Name: S17W-16
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1326595393
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326595392}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 27, y: 54, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1326595394
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326595392}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-16
+  mapByteOffset: 22072
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1326851521
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1326851522}
+  - component: {fileID: 1326851523}
+  m_Layer: 0
+  m_Name: S17W-41
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1326851522
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326851521}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 72, y: 56, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1326851523
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1326851521}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-41
+  mapByteOffset: 21726
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1344401795
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 121.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: GreyportRuins
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: GreyportRuins
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1344401796 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1344401795}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1365059678
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Dethal
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 99
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 104
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Dethal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1365059679 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1365059678}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1372628045
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Dunethel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 61
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 84
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Dunethel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1372628046 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1372628045}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1373704925
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: BaladNaran
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 91
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 52
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: BaladNaran
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1373704926 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1373704925}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1377456714
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Tal
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 52
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 149
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Tal
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1377456715 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1377456714}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1388347261
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 57.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 74.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DarkBarrows
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DarkBarrows
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1388347262 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1388347261}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1408701213
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1408701214}
+  - component: {fileID: 1408701215}
+  m_Layer: 0
+  m_Name: S17W-17
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1408701214
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1408701213}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 35, y: 69, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1408701215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1408701213}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-17
+  mapByteOffset: 18818
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1416735526
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1416735527}
+  - component: {fileID: 1416735528}
+  m_Layer: 0
+  m_Name: S17W-35
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1416735527
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416735526}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 67, y: 14, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1416735528
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1416735526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-35
+  mapByteOffset: 30872
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1436900352
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Charling
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 49
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Charling
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1436900353 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1436900352}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1439895712
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1439895713}
+  - component: {fileID: 1439895714}
+  m_Layer: 0
+  m_Name: S17W-22
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1439895713
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1439895712}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 49, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1439895714
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1439895712}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-22
+  mapByteOffset: 9472
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1458780984
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Malikor
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 99
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 118
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Malikor
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1458780985 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1458780984}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1467920232
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Khorfe
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 26
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Khorfe
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1467920233 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1467920232}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1469420215
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: ArArak
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 96
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 76
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: ArArak
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1469420216 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1469420215}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1492071018
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1492071019}
+  - component: {fileID: 1492071020}
+  m_Layer: 0
+  m_Name: S17W-14
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1492071019
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492071018}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 23, y: 128, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1492071020
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1492071018}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-14
+  mapByteOffset: 5932
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1493893282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1493893283}
+  - component: {fileID: 1493893284}
+  m_Layer: 0
+  m_Name: S17W-31
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1493893283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493893282}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 57, y: 22, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1493893284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493893282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-31
+  mapByteOffset: 29108
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1494044689 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6703045709133836705, guid: d6d52c5e10715ff4aa2380c9e0e73b81,
+    type: 3}
+  m_PrefabInstance: {fileID: 3274794878370800250}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1514754328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1514754329}
+  m_Layer: 0
+  m_Name: SiteAnchors
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1514754329
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1514754328}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1002437174}
+  - {fileID: 910195322}
+  - {fileID: 809944868}
+  - {fileID: 85054330}
+  - {fileID: 38921313}
+  - {fileID: 2099209210}
+  - {fileID: 567445007}
+  - {fileID: 872835108}
+  - {fileID: 842641684}
+  - {fileID: 1557141566}
+  - {fileID: 2106395013}
+  - {fileID: 1833791122}
+  - {fileID: 871083410}
+  - {fileID: 1492071019}
+  - {fileID: 343968263}
+  - {fileID: 1326595393}
+  - {fileID: 1408701214}
+  - {fileID: 162050406}
+  - {fileID: 1152646980}
+  - {fileID: 689356271}
+  - {fileID: 1769373292}
+  - {fileID: 1439895713}
+  - {fileID: 1236574097}
+  - {fileID: 1922451142}
+  - {fileID: 812748061}
+  - {fileID: 433104252}
+  - {fileID: 1194297034}
+  - {fileID: 1176539328}
+  - {fileID: 320295935}
+  - {fileID: 1706517214}
+  - {fileID: 1493893283}
+  - {fileID: 8041233}
+  - {fileID: 445483887}
+  - {fileID: 1921634616}
+  - {fileID: 1416735527}
+  - {fileID: 1243225850}
+  - {fileID: 631875745}
+  - {fileID: 1534047778}
+  - {fileID: 1644163398}
+  - {fileID: 682159763}
+  - {fileID: 1326851522}
+  - {fileID: 589504811}
+  - {fileID: 742175815}
+  - {fileID: 1166298027}
+  - {fileID: 1930688839}
+  - {fileID: 894916844}
+  - {fileID: 2120414843}
+  - {fileID: 1519224212}
+  - {fileID: 1001371043}
+  - {fileID: 1560465283}
+  - {fileID: 999549708}
+  - {fileID: 1994585137}
+  - {fileID: 899312187}
+  - {fileID: 1938996416}
+  - {fileID: 2052521291}
+  - {fileID: 2024235915}
+  - {fileID: 238624482}
+  - {fileID: 718562109}
+  - {fileID: 342016551}
+  - {fileID: 416142521}
+  - {fileID: 79958439}
+  - {fileID: 336941998}
+  - {fileID: 433237538}
+  - {fileID: 597160007}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1517531141
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Garom
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 88
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 41
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Garom
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1517531142 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1517531141}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1519224211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1519224212}
+  - component: {fileID: 1519224213}
+  m_Layer: 0
+  m_Name: S17W-48
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1519224212
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519224211}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 77, y: 142, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1519224213
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1519224211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-48
+  mapByteOffset: 2988
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
 --- !u!1 &1519475457
 GameObject:
   m_ObjectHideFlags: 0
@@ -10579,28 +10802,28 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1519475457}
   m_CullTransparentMesh: 1
---- !u!1001 &1523166801
+--- !u!1001 &1527006123
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: DharKhosis
+      value: Enmouth
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 37
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 74
+      value: 116
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -10645,336 +10868,20 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: DharKhosis
+      value: Enmouth
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1523166802 stripped
+--- !u!4 &1527006124 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1523166801}
+  m_PrefabInstance: {fileID: 1527006123}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1541066204
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 49.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 144.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: DruidsTemple
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: DruidsTemple
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1541066205 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1541066204}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1546381380
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Upbourne
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 11
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 91
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Upbourne
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1546381381 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1546381380}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1552600067
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Loremark
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 43
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Loremark
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1552600068 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1552600067}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1553444546
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: CitadelofFire
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 59
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 73
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: CitadelofFire
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1553444547 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1553444546}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1577780677
+--- !u!1 &1534047777
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -10982,44 +10889,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1577780678}
-  - component: {fileID: 1577780679}
+  - component: {fileID: 1534047778}
+  - component: {fileID: 1534047779}
   m_Layer: 0
-  m_Name: S17W-11
+  m_Name: S17W-38
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1577780678
+--- !u!4 &1534047778
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1577780677}
+  m_GameObject: {fileID: 1534047777}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 20, y: 17, z: 0}
+  m_LocalPosition: {x: 70, y: 18, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1577780679
+--- !u!114 &1534047779
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1577780677}
+  m_GameObject: {fileID: 1534047777}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-11
-  mapByteOffset: 30124
+  siteAnchorId: S17W-38
+  mapByteOffset: 30006
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -11027,97 +10934,519 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1001 &1598342654
+--- !u!1 &1557141565
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1557141566}
+  - component: {fileID: 1557141567}
+  m_Layer: 0
+  m_Name: S17W-10
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1557141566
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1557141565}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 19, y: 117, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1557141567
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1557141565}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-10
+  mapByteOffset: 8322
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1560465282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1560465283}
+  - component: {fileID: 1560465284}
+  m_Layer: 0
+  m_Name: S17W-50
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1560465283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560465282}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 77, y: 112, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1560465284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1560465282}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-50
+  mapByteOffset: 9528
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1569201718
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Ssuri
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 66.5
+      value: 60
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 53.5
+      value: 44
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: Gemhold
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Gemhold
+      value: Ssuri
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1598342655 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1569201719 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1598342654}
+  m_PrefabInstance: {fileID: 1569201718}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1605303583
+--- !u!1001 &1610916719
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Gluk
+      value: Gunthang
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 33
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gunthang
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1610916720 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1610916719}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1611408678
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Quiesce
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 36
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Quiesce
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1611408679 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1611408678}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1626937738
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Argrond
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 89
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 116
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Argrond
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1626937739 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1626937738}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1639071803
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Waybourne
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 104
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Waybourne
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1639071804 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1639071803}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1640218700
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Paynor
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -11127,7 +11456,7 @@ PrefabInstance:
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 25
+      value: 90
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -11172,99 +11501,20 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Gluk
+      value: Paynor
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1605303584 stripped
+--- !u!4 &1640218701 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1605303583}
+  m_PrefabInstance: {fileID: 1640218700}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1620176427
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 24.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 29.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: ThroneofBalnor
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: ThroneofBalnor
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1620176428 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1620176427}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1638157247
+--- !u!1 &1644163397
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -11272,44 +11522,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1638157248}
-  - component: {fileID: 1638157249}
+  - component: {fileID: 1644163398}
+  - component: {fileID: 1644163399}
   m_Layer: 0
-  m_Name: S17W-15
+  m_Name: S17W-39
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1638157248
+--- !u!4 &1644163398
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1638157247}
+  m_GameObject: {fileID: 1644163397}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 23, y: 116, z: 0}
+  m_LocalPosition: {x: 72, y: 114, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1638157249
+--- !u!114 &1644163399
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1638157247}
+  m_GameObject: {fileID: 1644163397}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-15
-  mapByteOffset: 8548
+  siteAnchorId: S17W-39
+  mapByteOffset: 9082
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -11317,28 +11567,28 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1001 &1641722177
+--- !u!1001 &1651814730
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Herzag
+      value: Elvallie
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 78
+      value: 42
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 67
+      value: 31
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -11383,290 +11633,26 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Herzag
+      value: Elvallie
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1641722178 stripped
+--- !u!4 &1651814731 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1641722177}
+  m_PrefabInstance: {fileID: 1651814730}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1660598209
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1660598210}
-  - component: {fileID: 1660598211}
-  m_Layer: 0
-  m_Name: S17W-51
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1660598210
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1660598209}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 81, y: 59, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1660598211
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1660598209}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-51
-  mapByteOffset: 21090
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1727064487
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1727064488}
-  - component: {fileID: 1727064489}
-  m_Layer: 0
-  m_Name: S17W-34
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1727064488
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727064487}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 65, y: 102, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1727064489
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1727064487}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-34
-  mapByteOffset: 11684
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1751642075
+--- !u!1001 &1677546728
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Upway
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 46
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 101
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Upway
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1751642076 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1751642075}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1773672587
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Wellmore
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 51
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Wellmore
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1773672588 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1773672587}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1779931296
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -11733,92 +11719,13 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1779931297 stripped
+--- !u!4 &1677546729 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 1779931296}
+  m_PrefabInstance: {fileID: 1677546728}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1783643537
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 105.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 22.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_Name
-      value: TempleofLurinth
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: locationShortName
-      value: TempleofLurinth
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &1783643538 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-    type: 3}
-  m_PrefabInstance: {fileID: 1783643537}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1792841182
+--- !u!1 &1706517213
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -11826,436 +11733,8 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1792841183}
-  - component: {fileID: 1792841184}
-  m_Layer: 0
-  m_Name: S17W-10
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1792841183
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1792841182}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 19, y: 117, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1792841184
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1792841182}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-10
-  mapByteOffset: 8322
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!224 &1804101478 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7479798158668484229, guid: f6b373a3c5d10614dbef98eb81cfab37,
-    type: 3}
-  m_PrefabInstance: {fileID: 7479798159028660707}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1814254250
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Hithos
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 20
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 70
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Hithos
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1814254251 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1814254250}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1823262578
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 77.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 34.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: locationShortName
-      value: DwarfHalls
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: DwarfHalls
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1823262579 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-    type: 3}
-  m_PrefabInstance: {fileID: 1823262578}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1829056165
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1829056166}
-  - component: {fileID: 1829056167}
-  m_Layer: 0
-  m_Name: S17W-09
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1829056166
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1829056165}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 18, y: 113, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1829056167
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1829056165}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-09
-  mapByteOffset: 9192
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1837246514
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Gork
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 86
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Gork
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1837246515 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1837246514}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1837989428
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Ssuri
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 59
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 43
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Ssuri
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1837989429 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1837989428}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1839947479
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1839947480}
-  - component: {fileID: 1839947481}
+  - component: {fileID: 1706517214}
+  - component: {fileID: 1706517215}
   m_Layer: 0
   m_Name: S17W-30
   m_TagString: Untagged
@@ -12263,28 +11742,28 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1839947480
+--- !u!4 &1706517214
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1839947479}
+  m_GameObject: {fileID: 1706517213}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 57, y: 29, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1839947481
+--- !u!114 &1706517215
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1839947479}
+  m_GameObject: {fileID: 1706517213}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
@@ -12299,13 +11778,92 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1001 &1845674350
+--- !u!1001 &1723312375
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Ohmsmouth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 61
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Ohmsmouth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1723312376 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1723312375}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1735097267
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -12372,244 +11930,34 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1845674351 stripped
+--- !u!4 &1735097268 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 1845674350}
+  m_PrefabInstance: {fileID: 1735097267}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &1860121019
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1860121021}
-  - component: {fileID: 1860121020}
-  m_Layer: 0
-  m_Name: Locations
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1860121020
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1860121019}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7a860770c2175fa4db0bef3e7b3b5a2f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.LocationContainer
-  ImportLocationsFromTilemap: 0
-  Reset: 0
-  LibraryPrefab: {fileID: 0}
-  RuinsPrefab: {fileID: 0}
-  SagePrefab: {fileID: 0}
-  TemplePrefab: {fileID: 0}
-  TombPrefab: {fileID: 0}
-  TotalLocations: 0
---- !u!4 &1860121021
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1860121019}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 425138700}
-  - {fileID: 953755986}
-  - {fileID: 333493214}
-  - {fileID: 2025305584}
-  - {fileID: 737233883}
-  - {fileID: 29706987}
-  - {fileID: 1783643538}
-  - {fileID: 1965348406}
-  - {fileID: 463877896}
-  - {fileID: 371174454}
-  - {fileID: 1083960863}
-  - {fileID: 941280969}
-  - {fileID: 1541066205}
-  - {fileID: 1779931297}
-  - {fileID: 885622284}
-  - {fileID: 804887381}
-  - {fileID: 1993925771}
-  - {fileID: 1413564459}
-  - {fileID: 645376916}
-  - {fileID: 2050259357}
-  - {fileID: 865215782}
-  - {fileID: 651858885}
-  - {fileID: 609163788}
-  - {fileID: 1270896111}
-  - {fileID: 199481286}
-  - {fileID: 700803661}
-  - {fileID: 1620176428}
-  - {fileID: 1445124152}
-  - {fileID: 77911054}
-  - {fileID: 2109113713}
-  - {fileID: 1200497010}
-  - {fileID: 1293150455}
-  - {fileID: 1598342655}
-  - {fileID: 955276895}
-  - {fileID: 1823262579}
-  - {fileID: 1503230852}
-  - {fileID: 568907618}
-  - {fileID: 1026372774}
-  - {fileID: 1308561382}
-  - {fileID: 1845674351}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1868516698 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 7972507524430896441, guid: eef716d4c750af84b9ab4224489408c5,
-    type: 3}
-  m_PrefabInstance: {fileID: 7972507522999930979}
-  m_PrefabAsset: {fileID: 0}
---- !u!224 &1868516699 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7972507524430896440, guid: eef716d4c750af84b9ab4224489408c5,
-    type: 3}
-  m_PrefabInstance: {fileID: 7972507522999930979}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1874487366
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1874487367}
-  - component: {fileID: 1874487368}
-  m_Layer: 0
-  m_Name: S17W-41
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1874487367
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1874487366}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 72, y: 56, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1874487368
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1874487366}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-41
-  mapByteOffset: 21726
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1 &1875173422
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1875173423}
-  - component: {fileID: 1875173424}
-  m_Layer: 0
-  m_Name: S17W-48
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1875173423
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1875173422}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 77, y: 142, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1875173424
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1875173422}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-48
-  mapByteOffset: 2988
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1878608645
+--- !u!1001 &1767064339
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Paynor
+      value: Zaigonne
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 83
+      value: 84
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 89
+      value: 151
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -12654,257 +12002,20 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Paynor
+      value: Zaigonne
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1878608646 stripped
+--- !u!4 &1767064340 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 1878608645}
+  m_PrefabInstance: {fileID: 1767064339}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &1879778974
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Needleton
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 56
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 127
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Needleton
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1879778975 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1879778974}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1880705472
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Maridun
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 57
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 97
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Maridun
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1880705473 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1880705472}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1892315348
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Thurtz
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 85
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 65
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Thurtz
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1892315349 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1892315348}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1916110662
+--- !u!1 &1769373291
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -12912,44 +12023,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 1916110663}
-  - component: {fileID: 1916110664}
+  - component: {fileID: 1769373292}
+  - component: {fileID: 1769373293}
   m_Layer: 0
-  m_Name: S17W-22
+  m_Name: S17W-21
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1916110663
+--- !u!4 &1769373292
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1916110662}
+  m_GameObject: {fileID: 1769373291}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 49, y: 112, z: 0}
+  m_LocalPosition: {x: 40, y: 74, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1916110664
+--- !u!114 &1769373293
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1916110662}
+  m_GameObject: {fileID: 1769373291}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-22
-  mapByteOffset: 9472
+  siteAnchorId: S17W-21
+  mapByteOffset: 17738
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -12957,293 +12068,23 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1 &1923041881
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1923041882}
-  - component: {fileID: 1923041883}
-  m_Layer: 0
-  m_Name: S17W-06
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1923041882
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1923041881}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 15, y: 72, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1923041883
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1923041881}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-06
-  mapByteOffset: 18124
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!224 &1946148656 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8642409218828357444, guid: ea2e4ebd299bfb1468a788172bf2b729,
-    type: 3}
-  m_PrefabInstance: {fileID: 8642409219572404340}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1954145111
+--- !u!1001 &1783881199
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: AlfarsGap
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 22
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 13
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: AlfarsGap
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &1954145112 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 1954145111}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &1965348405
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 21.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 131.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_Name
-      value: GrandOracle
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: locationShortName
-      value: GrandOracle
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &1965348406 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-    type: 3}
-  m_PrefabInstance: {fileID: 1965348405}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &1969623973
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1969623974}
-  - component: {fileID: 1969623975}
-  m_Layer: 0
-  m_Name: S17W-17
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1969623974
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1969623973}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 35, y: 69, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1969623975
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1969623973}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-17
-  mapByteOffset: 18818
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &1993925770
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 69.5
+      value: 94.5
       objectReference: {fileID: 0}
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 137.5
+      value: 33.5
       objectReference: {fileID: 0}
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -13288,46 +12129,46 @@ PrefabInstance:
     - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: locationShortName
-      value: MirksDecay
+      value: TombofNaar
       objectReference: {fileID: 0}
     - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_Name
-      value: MirksDecay
+      value: TombofNaar
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &1993925771 stripped
+--- !u!4 &1783881200 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 1993925770}
+  m_PrefabInstance: {fileID: 1783881199}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2013534729
+--- !u!1001 &1791786467
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Pareth
+      value: AkEnlie
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 57
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 138
+      value: 121
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -13372,184 +12213,105 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Pareth
+      value: AkEnlie
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2013534730 stripped
+--- !u!4 &1791786468 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 2013534729}
+  m_PrefabInstance: {fileID: 1791786467}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2025305583
+--- !u!1001 &1798533379
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 11.5
+      value: 77.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 38.5
+      value: 34.5
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
-        type: 3}
-      propertyPath: m_Name
-      value: GoldenLibrary
-      objectReference: {fileID: 0}
-    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: locationShortName
-      value: GoldenLibrary
+      value: DwarfHalls
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
---- !u!4 &2025305584 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
-    type: 3}
-  m_PrefabInstance: {fileID: 2025305583}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2046591603
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Argrond
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 88
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 115
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
       propertyPath: m_Name
-      value: Argrond
+      value: DwarfHalls
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2046591604 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1798533380 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 2046591603}
+  m_PrefabInstance: {fileID: 1798533379}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2050259356
+--- !u!1001 &1798985604
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
     - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
         type: 3}
@@ -13616,13 +12378,177 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &2050259357 stripped
+--- !u!4 &1798985605 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
     type: 3}
-  m_PrefabInstance: {fileID: 2050259356}
+  m_PrefabInstance: {fileID: 1798985604}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &2051036622
+--- !u!224 &1804101478 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7479798158668484229, guid: f6b373a3c5d10614dbef98eb81cfab37,
+    type: 3}
+  m_PrefabInstance: {fileID: 7479798159028660707}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1815260979
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Meneloth
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 118
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Meneloth
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1815260980 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1815260979}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1821677851
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 74.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 8.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: TempleofMiridine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: TempleofMiridine
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &1821677852 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 1821677851}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1833791121
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -13630,44 +12556,1539 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2051036623}
-  - component: {fileID: 2051036624}
+  - component: {fileID: 1833791122}
+  - component: {fileID: 1833791123}
   m_Layer: 0
-  m_Name: S17W-08
+  m_Name: S17W-12
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2051036623
+--- !u!4 &1833791122
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2051036622}
+  m_GameObject: {fileID: 1833791121}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 18, y: 125, z: 0}
+  m_LocalPosition: {x: 22, y: 30, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2051036624
+--- !u!114 &1833791123
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2051036622}
+  m_GameObject: {fileID: 1833791121}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-08
-  mapByteOffset: 6576
+  siteAnchorId: S17W-12
+  mapByteOffset: 27294
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1834885221
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 102.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 154.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: m_Name
+      value: TempleofEmrik
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: TempleofEmrik
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &1834885222 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
+    type: 3}
+  m_PrefabInstance: {fileID: 1834885221}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1853914090
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Deephallow
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 61
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Deephallow
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1853914091 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1853914090}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1865566423
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Hithos
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 71
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Hithos
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1865566424 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1865566423}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1868516698 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7972507524430896441, guid: eef716d4c750af84b9ab4224489408c5,
+    type: 3}
+  m_PrefabInstance: {fileID: 7972507522999930979}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1868516699 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 7972507524430896440, guid: eef716d4c750af84b9ab4224489408c5,
+    type: 3}
+  m_PrefabInstance: {fileID: 7972507522999930979}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1919037697
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: BanesCitadel
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 93
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 131
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: BanesCitadel
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1919037698 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1919037697}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1921634615
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1921634616}
+  - component: {fileID: 1921634617}
+  m_Layer: 0
+  m_Name: S17W-34
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1921634616
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921634615}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 65, y: 102, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1921634617
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1921634615}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-34
+  mapByteOffset: 11684
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1922451141
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1922451142}
+  - component: {fileID: 1922451143}
+  m_Layer: 0
+  m_Name: S17W-24
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1922451142
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922451141}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 50, y: 17, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1922451143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1922451141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-24
+  mapByteOffset: 30184
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &1930688838
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1930688839}
+  - component: {fileID: 1930688840}
+  m_Layer: 0
+  m_Name: S17W-45
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1930688839
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930688838}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 73, y: 32, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1930688840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1930688838}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-45
+  mapByteOffset: 26960
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &1937023539
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 49.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 144.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: DruidsTemple
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: DruidsTemple
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &1937023540 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 1937023539}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1938996415
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1938996416}
+  - component: {fileID: 1938996417}
+  m_Layer: 0
+  m_Name: S17W-54
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1938996416
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938996415}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 89, y: 77, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1938996417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1938996415}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-54
+  mapByteOffset: 17182
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!224 &1946148656 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8642409218828357444, guid: ea2e4ebd299bfb1468a788172bf2b729,
+    type: 3}
+  m_PrefabInstance: {fileID: 8642409219572404340}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1983314402
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Tirfing
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 69
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 144
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Tirfing
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1983314403 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1983314402}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1993007802
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gimlad
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 68
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gimlad
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &1993007803 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 1993007802}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1994585136
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1994585137}
+  - component: {fileID: 1994585138}
+  m_Layer: 0
+  m_Name: S17W-52
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1994585137
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1994585136}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 84, y: 137, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1994585138
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1994585136}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-52
+  mapByteOffset: 4092
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &2000980865
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 24.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 33.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: TheOldInn
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: TheOldInn
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &2000980866 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2000980865}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2018454231
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 817785890}
+    m_Modifications:
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 66.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 53.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: locationShortName
+      value: Gemhold
+      objectReference: {fileID: 0}
+    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
+        type: 3}
+      propertyPath: m_Name
+      value: Gemhold
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
+--- !u!4 &2018454232 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+    type: 3}
+  m_PrefabInstance: {fileID: 2018454231}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2020521106
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Tasme
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 43
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Tasme
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2020521107 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2020521106}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2024235914
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2024235915}
+  - component: {fileID: 2024235916}
+  m_Layer: 0
+  m_Name: S17W-56
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2024235915
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2024235914}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 91, y: 63, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2024235916
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2024235914}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-56
+  mapByteOffset: 20238
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &2028243814
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Lador
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 32
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Lador
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2028243815 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2028243814}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2031997038
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Gorag
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 95
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 137
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Gorag
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2031997039 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2031997038}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2034334898
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: Marton
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 110
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: Marton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2034334899 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2034334898}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2035028067
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 910678733}
+    m_Modifications:
+    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: cityShortName
+      value: AkFarzon
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 121
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_Name
+      value: AkFarzon
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
+--- !u!4 &2035028068 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    type: 3}
+  m_PrefabInstance: {fileID: 2035028067}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &2052521290
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2052521291}
+  - component: {fileID: 2052521292}
+  m_Layer: 0
+  m_Name: S17W-55
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2052521291
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2052521290}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 90, y: 43, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2052521292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2052521290}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-55
+  mapByteOffset: 24596
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -14389,31 +14810,31 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1913c3afdd517ee49805ac6175fa2a08, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1001 &2060731879
+--- !u!1001 &2077725658
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Herueth
+      value: Kazrak
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
+      value: 59
+      objectReference: {fileID: 0}
+    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+        type: 3}
+      propertyPath: m_LocalPosition.y
       value: 65
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 32
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
@@ -14455,178 +14876,20 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Herueth
+      value: Kazrak
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2060731880 stripped
+--- !u!4 &2077725659 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 2060731879}
+  m_PrefabInstance: {fileID: 2077725658}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2065589676
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Derridon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 54
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 82
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Derridon
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2065589677 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 2065589676}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2067220330
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Gorag
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 94
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 136
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Gorag
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2067220331 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 2067220330}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2086883950
+--- !u!1 &2099209209
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -14634,44 +14897,44 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2086883951}
-  - component: {fileID: 2086883952}
+  - component: {fileID: 2099209210}
+  - component: {fileID: 2099209211}
   m_Layer: 0
-  m_Name: S17W-07
+  m_Name: S17W-06
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2086883951
+--- !u!4 &2099209210
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2086883950}
+  m_GameObject: {fileID: 2099209209}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 15, y: 28, z: 0}
+  m_LocalPosition: {x: 15, y: 72, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 818195351}
+  m_Father: {fileID: 1514754329}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2086883952
+--- !u!114 &2099209211
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2086883950}
+  m_GameObject: {fileID: 2099209209}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
   m_Name: 
   m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-07
-  mapByteOffset: 27716
+  siteAnchorId: S17W-06
+  mapByteOffset: 18124
   rawWord: 0x8117
   lowByte: 23
   highByte: 129
@@ -14679,28 +14942,134 @@ MonoBehaviour:
   sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
     word-map export. This is scene/debug support data, not a gameplay Location.json
     row.
---- !u!1001 &2087984151
+--- !u!1 &2106395012
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2106395013}
+  - component: {fileID: 2106395014}
+  m_Layer: 0
+  m_Name: S17W-11
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2106395013
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106395012}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 20, y: 17, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2106395014
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106395012}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-11
+  mapByteOffset: 30124
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1 &2120414842
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2120414843}
+  - component: {fileID: 2120414844}
+  m_Layer: 0
+  m_Name: S17W-47
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2120414843
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2120414842}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 77, y: 144, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1514754329}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2120414844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2120414842}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
+  siteAnchorId: S17W-47
+  mapByteOffset: 2552
+  rawWord: 0x8117
+  lowByte: 23
+  highByte: 129
+  terrain: Ruins
+  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
+    word-map export. This is scene/debug support data, not a gameplay Location.json
+    row.
+--- !u!1001 &2127245225
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 910678733}
     m_Modifications:
     - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: cityShortName
-      value: Argenthorn
+      value: CitadelofFire
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 42
+      value: 60
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 41
+      value: 74
       objectReference: {fileID: 0}
     - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
@@ -14745,545 +15114,176 @@ PrefabInstance:
     - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
         type: 3}
       propertyPath: m_Name
-      value: Argenthorn
+      value: CitadelofFire
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2087984152 stripped
+--- !u!4 &2127245226 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
     type: 3}
-  m_PrefabInstance: {fileID: 2087984151}
+  m_PrefabInstance: {fileID: 2127245225}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2094990717
+--- !u!1001 &2133646697
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Vernon
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 48
+      value: 21.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 65
+      value: 131.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_Name
-      value: Vernon
+      value: GrandOracle
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2094990718 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 2094990717}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2109113712
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 1860121021}
-    m_Modifications:
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 34.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 10.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4334975969769317555, guid: a0fa8051bee43814b90bd4d3042327c6,
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: locationShortName
-      value: RuinsofHaviel
-      objectReference: {fileID: 0}
-    - target: {fileID: 8098070422210760935, guid: a0fa8051bee43814b90bd4d3042327c6,
-        type: 3}
-      propertyPath: m_Name
-      value: RuinsofHaviel
+      value: GrandOracle
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: a0fa8051bee43814b90bd4d3042327c6, type: 3}
---- !u!4 &2109113713 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &2133646698 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 1780767620331047231, guid: a0fa8051bee43814b90bd4d3042327c6,
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
     type: 3}
-  m_PrefabInstance: {fileID: 2109113712}
+  m_PrefabInstance: {fileID: 2133646697}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &2116387896
+--- !u!1001 &2145851601
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
     serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
+    m_TransformParent: {fileID: 817785890}
     m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Angbar
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 54
+      value: 105.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 45
+      value: 22.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
+    - target: {fileID: 5438964329468570372, guid: 3261dafbb42665c43871be91b8575235,
         type: 3}
       propertyPath: m_Name
-      value: Angbar
+      value: TempleofLurinth
+      objectReference: {fileID: 0}
+    - target: {fileID: 6040693178244014188, guid: 3261dafbb42665c43871be91b8575235,
+        type: 3}
+      propertyPath: locationShortName
+      value: TempleofLurinth
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2116387897 stripped
+  m_SourcePrefab: {fileID: 100100000, guid: 3261dafbb42665c43871be91b8575235, type: 3}
+--- !u!4 &2145851602 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
+  m_CorrespondingSourceObject: {fileID: 2571480269850637020, guid: 3261dafbb42665c43871be91b8575235,
     type: 3}
-  m_PrefabInstance: {fileID: 2116387896}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2119169034
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Zaigonne
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 83
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 150
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Zaigonne
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2119169035 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 2119169034}
-  m_PrefabAsset: {fileID: 0}
---- !u!1001 &2124823449
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Lador
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 31
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 49
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Lador
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2124823450 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 2124823449}
-  m_PrefabAsset: {fileID: 0}
---- !u!1 &2132718335
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2132718336}
-  - component: {fileID: 2132718337}
-  m_Layer: 0
-  m_Name: S17W-23
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2132718336
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2132718335}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 50, y: 19, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 818195351}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2132718337
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2132718335}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f7a4a293fe341d4ab9a9104d9348762, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityGame::Assets.Scripts.Editors.IlluriaSiteAnchorEntry
-  siteAnchorId: S17W-23
-  mapByteOffset: 29748
-  rawWord: 0x8117
-  lowByte: 23
-  highByte: 129
-  terrain: Ruins
-  sourceNote: Low-byte 0x17 structural site/support anchor from corrected Illuria
-    word-map export. This is scene/debug support data, not a gameplay Location.json
-    row.
---- !u!1001 &2142612330
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 522548138}
-    m_Modifications:
-    - target: {fileID: 1719936749520935755, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: cityShortName
-      value: Troy
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 56
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 40
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6050287556462830519, guid: 456f6178cdc59724b8999080eed2bfcd,
-        type: 3}
-      propertyPath: m_Name
-      value: Troy
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 456f6178cdc59724b8999080eed2bfcd, type: 3}
---- !u!4 &2142612331 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 4261072556348357231, guid: 456f6178cdc59724b8999080eed2bfcd,
-    type: 3}
-  m_PrefabInstance: {fileID: 2142612330}
+  m_PrefabInstance: {fileID: 2145851601}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &147419114341941526
 PrefabInstance:
@@ -439574,6 +439574,6 @@ SceneRoots:
   - {fileID: 222812357}
   - {fileID: 149804624}
   - {fileID: 93653620}
-  - {fileID: 522548138}
-  - {fileID: 1860121021}
-  - {fileID: 818195351}
+  - {fileID: 910678733}
+  - {fileID: 817785890}
+  - {fileID: 1514754329}

--- a/WismUnity/Assets/Scripts/UnityGame/Editors/CityEntry.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Editors/CityEntry.cs
@@ -15,8 +15,9 @@ namespace Assets.Scripts.Editors
 
             var coords = worldTilemap.ConvertUnityToGameVector(this.gameObject.transform.position);
 
-            // Center on top-left of city
-            return new Vector2Int(coords.x, coords.y + 1);
+            // City markers are centered on the 2x2 footprint. Convert back to
+            // the top-left tile used by WismClient city coordinates.
+            return new Vector2Int(coords.x - 1, coords.y);
         }
 
 #if UNITY_EDITOR

--- a/WismUnity/Assets/Scripts/UnityGame/Factories/UnityCityFactory.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Factories/UnityCityFactory.cs
@@ -57,14 +57,14 @@ namespace Assets.Scripts.UnityGame.Factories
                 if (citiesNames.ContainsKey(ci.ShortName))
                 {
                     var go = citiesNames[ci.ShortName];
-                    var coords = unityManager.WorldTilemap.ConvertUnityToGameVector(go.transform.position);
+                    var coords = go.GetComponent<CityEntry>().GetGameCoordinates();
                     cities[cityIndex++] = new CityEntity()
                     {
                         CityShortName = ci.ShortName,
                         Defense = ci.Defense,
                         ClanShortName = ci.ClanName,
                         X = coords.x,
-                        Y = coords.y + 1    // +1 Adjustment for city object overlay alignment (anchor)
+                        Y = coords.y
                     };
                 }
             }

--- a/WismUnity/Assets/Scripts/UnityGame/Playground/Editor/WorldKitSceneBuilder.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Playground/Editor/WorldKitSceneBuilder.cs
@@ -479,7 +479,7 @@ namespace WismUnity.Playground
 
                 var go = InstantiateMarker(markerPrefab, scene, container.transform, shortName);
                 go.tag = "City";
-                go.transform.position = tilemap.CellToWorld(new Vector3Int(x, y - 1, 0));
+                go.transform.position = GetCityFootprintCenter(tilemap, x, y);
                 go.transform.localScale = new Vector3(2f, 2f, 1f);
                 EnsureComponent<CityEntry>(go).cityShortName = shortName;
                 EnsureComponent<SpriteRenderer>(go);
@@ -543,7 +543,7 @@ namespace WismUnity.Playground
                 .Where(city => !string.IsNullOrWhiteSpace(city.Value<string>("ShortName")))
                 .ToDictionary(
                     city => city.Value<string>("ShortName"),
-                    city => new Vector2(city.Value<int>("X"), ToUnityY(city.Value<int>("Y"), mapHeight) - 1),
+                    city => GetCityFootprintCenter(city.Value<int>("X"), ToUnityY(city.Value<int>("Y"), mapHeight)),
                     StringComparer.OrdinalIgnoreCase);
 
             return entries.All(entry =>
@@ -674,6 +674,20 @@ namespace WismUnity.Playground
                 origin.x + tilemap.cellSize.x * 0.5f,
                 origin.y + tilemap.cellSize.y * 0.5f,
                 origin.z);
+        }
+
+        static Vector3 GetCityFootprintCenter(Tilemap tilemap, int x, int topY)
+        {
+            var origin = tilemap.CellToWorld(new Vector3Int(x, topY, 0));
+            return new Vector3(
+                origin.x + tilemap.cellSize.x,
+                origin.y,
+                origin.z);
+        }
+
+        static Vector2 GetCityFootprintCenter(int x, int topY)
+        {
+            return new Vector2(x + 1, topY);
         }
 
         static GameObject EnsureSceneContainer<T>(Scene scene, string name) where T : Component


### PR DESCRIPTION
## Summary
- place generated city GameObjects at the visual center of their 2x2 city footprint
- update CityEntry and UnityCityFactory so centered city markers still resolve to the top-left WismClient city tile
- update the world-scene verifier expectation to catch city marker target drift

## Validation
- Unity batchmode isolated build: BuildIlluriaSceneFromCommandLine succeeded
- Unity batchmode isolated verifier: Illuria scene proof passed with 109x156 tiles, 80 city markers, 40 location markers, 64 site anchors, one Cities container, one Locations container, city/location runtime components, and marker alignment checks