### PR TITLE
Fix Illuria Unity launch mod path

### DIFF
--- a/WismUnity/Assets/Scenes/Illuria.unity
+++ b/WismUnity/Assets/Scenes/Illuria.unity
@@ -14170,8 +14170,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   StandardTime: 0.25
   WarTime: 1
-  worldName: Mini-Illuria
-  modPath: Assets\Mod
+  worldName: Illuria
+  modPath: Assets\Plugins\WismClient\Mods
 --- !u!114 &2053934882
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/WismUnity/Assets/Scripts/UnityGame/Factories/UnityCityFactory.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Factories/UnityCityFactory.cs
@@ -50,28 +50,36 @@ namespace Assets.Scripts.UnityGame.Factories
             var cityInfos = new List<CityInfo>(ModFactory.LoadCityInfos(path));
             this.debugManager.LogInformation("Loaded CityInfos: " + path);
 
-            var cities = new CityEntity[citiesNames.Count];
-            int cityIndex = 0;
+            var cities = new List<CityEntity>();
+            var unmatchedCityNames = new List<string>(citiesNames.Keys);
             foreach (CityInfo ci in cityInfos)
             {
                 if (citiesNames.ContainsKey(ci.ShortName))
                 {
                     var go = citiesNames[ci.ShortName];
                     var coords = go.GetComponent<CityEntry>().GetGameCoordinates();
-                    cities[cityIndex++] = new CityEntity()
+                    cities.Add(new CityEntity()
                     {
                         CityShortName = ci.ShortName,
                         Defense = ci.Defense,
                         ClanShortName = ci.ClanName,
                         X = coords.x,
                         Y = coords.y
-                    };
+                    });
+                    unmatchedCityNames.Remove(ci.ShortName);
                 }
+            }
+
+            if (unmatchedCityNames.Count > 0)
+            {
+                this.debugManager.LogInformation(
+                    "Skipped scene City GameObjects with no matching City.json entry: " +
+                    string.Join(", ", unmatchedCityNames));
             }
 
             this.debugManager.LogInformation("Updated cities with coordinates from scene");
 
-            return cities;
+            return cities.ToArray();
         }
     }
 }

--- a/WismUnity/Assets/Scripts/UnityGame/Factories/UnityLocationFactory.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Factories/UnityLocationFactory.cs
@@ -51,26 +51,34 @@ namespace Assets.Scripts.UnityGame.Factories
                 (IEnumerable<LocationInfo>)ModFactory.LoadLocationInfos(path));
             this.debugManager.LogInformation("Loaded LocationInfos: " + path);
 
-            var locations = new LocationEntity[locationNames.Count];
-            int locationIndex = 0;
+            var locations = new List<LocationEntity>();
+            var unmatchedLocationNames = new List<string>(locationNames.Keys);
             foreach (LocationInfo ci in locationInfos)
             {
                 if (locationNames.ContainsKey(ci.ShortName))
                 {
                     var go = locationNames[ci.ShortName];
                     var coords = unityManger.WorldTilemap.ConvertUnityToGameVector(go.transform.position);
-                    locations[locationIndex++] = new LocationEntity()
+                    locations.Add(new LocationEntity()
                     {
                         LocationShortName = ci.ShortName,
                         X = coords.x,
                         Y = coords.y
-                    };
+                    });
+                    unmatchedLocationNames.Remove(ci.ShortName);
                 }
+            }
+
+            if (unmatchedLocationNames.Count > 0)
+            {
+                this.debugManager.LogInformation(
+                    "Skipped scene Location GameObjects with no matching Location.json entry: " +
+                    string.Join(", ", unmatchedLocationNames));
             }
 
             this.debugManager.LogInformation("Updated locations with coordinates from scene");
 
-            return locations;
+            return locations.ToArray();
         }
     }
 }

--- a/WismUnity/Assets/Scripts/UnityGame/Playground/Editor/WorldKitSceneBuilder.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Playground/Editor/WorldKitSceneBuilder.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Assets.Scripts;
 using Assets.Scripts.Editors;
+using Assets.Scripts.Managers;
 using Assets.Scripts.Tiles;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
@@ -155,7 +157,7 @@ namespace WismUnity.Playground
                 var siteAnchors = LoadOptionalRecords(Path.Combine(worldRoot, "SiteAnchor.json"));
 
                 ConfigureGeneratedContainers(scene, cities.Count, locations.Count);
-                NormalizeGeneratedScene(scene, tilemap);
+                NormalizeGeneratedScene(scene, tilemap, world);
                 ClearEditorTileCaches();
                 var mapHeight = ComputeMapHeight(tiles);
                 PaintTerrain(tilemap, tiles, mapHeight);
@@ -260,6 +262,12 @@ namespace WismUnity.Playground
                 AddSceneCheck(SiteAnchorPositionsMatch(siteAnchorEntries, siteAnchors, mapHeight), checks, issues, "Scene site anchor marker positions match flipped MOD coordinates.", "Scene site anchor marker positions do not match flipped MOD coordinates.");
                 AddSceneCheck(CityFootprintsArePainted(tilemap, cities, mapHeight), checks, issues, "City markers line up with painted 2x2 city footprints.", "One or more city markers do not line up with painted 2x2 city footprints.");
                 AddSceneCheck(LocationTilesArePainted(tilemap, locations, mapHeight), checks, issues, "Location markers line up with painted location tiles.", "One or more location markers do not line up with painted location tiles.");
+                AddSceneCheck(
+                    SceneUsesGeneratedWorldDefaults(scene, world),
+                    checks,
+                    issues,
+                    "Scene GameManager and UnityGameFactory use generated world defaults.",
+                    "Scene GameManager or UnityGameFactory still points at stale world/mod defaults.");
 
                 return new JObject
                 {
@@ -638,7 +646,7 @@ namespace WismUnity.Playground
                    Mathf.Approximately(transform.localScale.z, 1f);
         }
 
-        static void NormalizeGeneratedScene(Scene scene, Tilemap tilemap)
+        static void NormalizeGeneratedScene(Scene scene, Tilemap tilemap, string world)
         {
             var grid = scene.GetRootGameObjects()
                 .FirstOrDefault(go => string.Equals(go.name, "Grid", StringComparison.OrdinalIgnoreCase));
@@ -653,6 +661,36 @@ namespace WismUnity.Playground
             tilemap.transform.localPosition = Vector3.zero;
             tilemap.transform.localScale = Vector3.one;
             tilemap.transform.localRotation = Quaternion.identity;
+
+            foreach (var gameManager in scene.GetRootGameObjects().SelectMany(root => root.GetComponentsInChildren<GameManager>(true)))
+            {
+                gameManager.WorldName = world;
+                gameManager.ModPath = GameManager.DefaultModPath;
+            }
+
+            foreach (var gameFactory in scene.GetRootGameObjects().SelectMany(root => root.GetComponentsInChildren<UnityGameFactory>(true)))
+            {
+                gameFactory.WorldName = world;
+                gameFactory.ModPath = GameManager.DefaultModPath;
+            }
+        }
+
+        static bool SceneUsesGeneratedWorldDefaults(Scene scene, string world)
+        {
+            var gameManagers = scene.GetRootGameObjects()
+                .SelectMany(root => root.GetComponentsInChildren<GameManager>(true))
+                .ToArray();
+            var gameFactories = scene.GetRootGameObjects()
+                .SelectMany(root => root.GetComponentsInChildren<UnityGameFactory>(true))
+                .ToArray();
+
+            return gameManagers.Length > 0 &&
+                   gameManagers.All(manager =>
+                       string.Equals(manager.WorldName, world, StringComparison.OrdinalIgnoreCase) &&
+                       string.Equals(manager.ModPath, GameManager.DefaultModPath, StringComparison.OrdinalIgnoreCase)) &&
+                   gameFactories.All(factory =>
+                       string.Equals(factory.WorldName, world, StringComparison.OrdinalIgnoreCase) &&
+                       string.Equals(factory.ModPath, GameManager.DefaultModPath, StringComparison.OrdinalIgnoreCase));
         }
 
         static int ComputeMapHeight(IReadOnlyList<JObject> tiles)


### PR DESCRIPTION
## Summary
- set the generated Illuria scene to load the Illuria world from the plugin MOD root instead of stale Assets\\Mod data
- make Unity city/location scene factories return only matched entities, preventing null entries from reaching WorldFactory
- extend the world scene verifier to catch stale generated world/mod defaults

## Root Cause
The Illuria scene still serialized GameManager with worldName=Mini-Illuria and modPath=Assets\\Mod. Unity therefore loaded legacy Illuria Location.json names that did not match the generated scene markers, and UnityLocationFactory returned a partially-filled array with null entries. WorldFactory then failed in LocationFactory.Create(locationEntity, world).

## Validation
- dotnet build WismClient\\WismClient.sln --configuration Release --nologo -v:minimal: passed
- git diff --check: passed
- Unity batchmode smoke attempted twice, but blocked before script execution by PackageCache EPERM while resolving com.unity.ai.assistant in the isolated worktree
- dotnet test WismClient\\WismClient.sln --configuration Release --no-build timed out at 120s; orphaned isolated testhost was stopped