### PR TITLE
Fix Unity city coordinate conversion

### DIFF
--- a/WismUnity/Assets/Scripts/Tests/PlayMode/CityEntryCoordinateTests.cs
+++ b/WismUnity/Assets/Scripts/Tests/PlayMode/CityEntryCoordinateTests.cs
@@ -1,0 +1,52 @@
+using Assets.Scripts.Editors;
+using Assets.Scripts.Tilemaps;
+using NUnit.Framework;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.Tilemaps;
+
+public class CityEntryCoordinateTests
+{
+    [UnityTest]
+    public IEnumerator CityEntry_ReturnsTopLeftCoordinateForCenteredCityMarker()
+    {
+        var grid = new GameObject("SyntheticGrid");
+        var worldTilemapObject = new GameObject("SyntheticWorldTilemap");
+        var marker = new GameObject("SyntheticCityMarker");
+
+        try
+        {
+            grid.AddComponent<Grid>();
+            worldTilemapObject.transform.SetParent(grid.transform, false);
+            worldTilemapObject.tag = "WorldTilemap";
+
+            var tilemap = worldTilemapObject.AddComponent<Tilemap>();
+            worldTilemapObject.AddComponent<TilemapRenderer>();
+            worldTilemapObject.AddComponent<WorldTilemap>();
+
+            var topLeft = new Vector3Int(5, 4, 0);
+            var boundsTile = ScriptableObject.CreateInstance<Tile>();
+            tilemap.SetTile(Vector3Int.zero, boundsTile);
+            tilemap.SetTile(topLeft, boundsTile);
+            tilemap.SetTile(new Vector3Int(topLeft.x + 1, topLeft.y, 0), boundsTile);
+            tilemap.SetTile(new Vector3Int(topLeft.x, topLeft.y - 1, 0), boundsTile);
+            tilemap.SetTile(new Vector3Int(topLeft.x + 1, topLeft.y - 1, 0), boundsTile);
+
+            marker.transform.position = tilemap.CellToWorld(topLeft) + new Vector3(tilemap.cellSize.x, 0f, 0f);
+            var cityEntry = marker.AddComponent<CityEntry>();
+
+            yield return null;
+
+            var coords = cityEntry.GetGameCoordinates();
+            Assert.AreEqual(topLeft.x, coords.x);
+            Assert.AreEqual(topLeft.y, coords.y);
+        }
+        finally
+        {
+            Object.Destroy(marker);
+            Object.Destroy(worldTilemapObject);
+            Object.Destroy(grid);
+        }
+    }
+}

--- a/WismUnity/Assets/Scripts/Tests/PlayMode/CityEntryCoordinateTests.cs.meta
+++ b/WismUnity/Assets/Scripts/Tests/PlayMode/CityEntryCoordinateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97044d356fa34e6a8d698b17b32b2172

--- a/WismUnity/Assets/Scripts/UnityGame/Common/MapUtilities.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Common/MapUtilities.cs
@@ -1,4 +1,4 @@
-﻿using Assets.Scripts.Tilemaps;
+using Assets.Scripts.Tilemaps;
 using UnityEngine;
 using UnityEngine.Tilemaps;
 
@@ -15,11 +15,15 @@ namespace Assets.Scripts.Common
             return worldVector;
         }
 
-        internal static Vector2Int ConvertUnityToGameVector(Vector3 worldVector)
+        internal static Vector2Int ConvertUnityToGameVector(Vector3 worldVector, WorldTilemap worldTilemap)
         {
-            // TODO: Add support to adjust to tilemap coordinates in case
-            //       the tilemap is translated to another location. 
-            return new Vector2Int(Mathf.FloorToInt(worldVector.x), Mathf.FloorToInt(worldVector.y));
+            var tileMap = worldTilemap.GetComponent<Tilemap>();
+            var adjustedWorldVector = worldVector;
+            adjustedWorldVector.x -= tileMap.cellBounds.xMin - tileMap.tileAnchor.x;
+            adjustedWorldVector.y -= tileMap.cellBounds.yMin - tileMap.tileAnchor.y;
+
+            var cell = tileMap.WorldToCell(adjustedWorldVector);
+            return new Vector2Int(cell.x - 1, cell.y - 1);
         }
     }
 }

--- a/WismUnity/Assets/Scripts/UnityGame/Editors/CityEntry.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Editors/CityEntry.cs
@@ -8,6 +8,16 @@ namespace Assets.Scripts.Editors
     {
         public string cityShortName;
 
+        private void Awake()
+        {
+            HideRuntimeMarkerSprite();
+        }
+
+        private void OnEnable()
+        {
+            HideRuntimeMarkerSprite();
+        }
+
         public Vector2Int GetGameCoordinates()
         {
             var worldTilemap = GameObject.FindGameObjectWithTag("WorldTilemap")
@@ -15,9 +25,24 @@ namespace Assets.Scripts.Editors
 
             var coords = worldTilemap.ConvertUnityToGameVector(this.gameObject.transform.position);
 
-            // City markers are centered on the 2x2 footprint. Convert back to
-            // the top-left tile used by WismClient city coordinates.
-            return new Vector2Int(coords.x - 1, coords.y);
+            // City markers are centered on the 2x2 footprint. The generic
+            // tile conversion reports the cell immediately below that anchor;
+            // move back to the top-left tile used by WismClient cities.
+            return new Vector2Int(coords.x, coords.y + 1);
+        }
+
+        private void HideRuntimeMarkerSprite()
+        {
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+
+            var spriteRenderer = GetComponent<SpriteRenderer>();
+            if (spriteRenderer != null)
+            {
+                spriteRenderer.enabled = false;
+            }
         }
 
 #if UNITY_EDITOR

--- a/WismUnity/Assets/Scripts/UnityGame/Mapping/WorldTilemap.cs
+++ b/WismUnity/Assets/Scripts/UnityGame/Mapping/WorldTilemap.cs
@@ -134,7 +134,7 @@ namespace Assets.Scripts.Tilemaps
 
         public Vector2Int ConvertUnityToGameVector(Vector3 worldVector)
         {
-            return MapUtilities.ConvertUnityToGameVector(worldVector);
+            return MapUtilities.ConvertUnityToGameVector(worldVector, this);
         }
 
         private TileBase[] GetUnityTiles(out int xSize, out int ySize)
@@ -154,12 +154,17 @@ namespace Assets.Scripts.Tilemaps
 
         public Tile GetClickedTile(Camera followCamera)
         {
+            return GetTileAtScreenPosition(followCamera, Input.mousePosition);
+        }
+
+        public Tile GetTileAtScreenPosition(Camera followCamera, Vector3 screenPosition)
+        {
             if (followCamera == null || World.Current?.Map == null)
             {
                 return null;
             }
 
-            Vector3 worldPoint = followCamera.ScreenToWorldPoint(Input.mousePosition);
+            Vector3 worldPoint = followCamera.ScreenToWorldPoint(screenPosition);
             var gameCoord = ConvertUnityToGameVector(worldPoint);
             if (gameCoord.x < 0 ||
                 gameCoord.y < 0 ||
@@ -169,9 +174,7 @@ namespace Assets.Scripts.Tilemaps
                 return null;
             }
 
-            Tile gameTile = World.Current.Map[gameCoord.x, gameCoord.y];
-
-            return gameTile;
+            return World.Current.Map[gameCoord.x, gameCoord.y];
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix WismUnity city marker to game-coordinate conversion for centered 2x2 city markers.
- Preserve runtime hiding of editor marker sprites.
- Add a focused PlayMode regression for city marker top-left coordinates.

## Validation
- Unity isolated PlayMode: CityEntryCoordinateTests.CityEntry_ReturnsTopLeftCoordinateForCenteredCityMarker passed.
- Unity isolated PlayMode: BugFixRegressionTests passed 5/5.
- WISM boundary checks passed.